### PR TITLE
Minor refactor - init() method extracted from handle()

### DIFF
--- a/restler/restler.php
+++ b/restler/restler.php
@@ -12,7 +12,7 @@
  * @link       http://luracast.com/products/restler/
  * @version    2.1.8
  */
-class Restler { 
+class Restler {
 	const VERSION = '2.1.8';
 	/**
 	 * URL of the currently mapped service
@@ -252,7 +252,7 @@ class Restler {
 				if($index!==FALSE){
 					$base_path=substr($base_path, $index+1);
 				}
-			}else			
+			}else
 				$base_path = trim($base_path,'/');
 			if(strlen($base_path)>0)$base_path .= '/';
 			$this->generateMap($class_name, $base_path);
@@ -303,15 +303,12 @@ class Restler {
 		$this->sendData($responder->__formatError($status_code, $message));
 	}
 
-	/**
-	 * Main function for processing the api request
-	 * and return the response
-	 * @throws Exception when the api service class is missing
-	 * @throws RestException to send error response
-	 */
-	public function handle () {
-		if(empty($this->format_map))$this->setSupportedFormats('JsonFormat');
-		$this->url = strtolower($this->getPath());
+  /**
+     * An initialize function to allow error responses prior to handling the request
+     */
+    public function init () {
+        if(empty($this->format_map))$this->setSupportedFormats('JsonFormat');
+		$this->url = $this->getPath();
 		$this->request_method = $this->getRequestMethod();
 		$this->response_format = $this->getResponseFormat();
 		$this->request_format = $this->getRequestFormat();
@@ -321,6 +318,16 @@ class Restler {
 		if($this->request_method == 'PUT' || $this->request_method == 'POST'){
 			$this->request_data = $this->getRequestData();
 		}
+    }
+
+	/**
+	 * Main function for processing the api request
+	 * and return the response
+	 * @throws Exception when the api service class is missing
+	 * @throws RestException to send error response
+	 */
+	public function handle () {
+		$this->init();
 		$o = $this->mapUrlToMethod();
 		if(!isset($o->class_name)){
 			$this->handleError(404);
@@ -462,7 +469,7 @@ class Restler {
 	* @return string api path
 	*/
 	protected function getPath () {
-		$path = urldecode($this->removeCommonPath($_SERVER['REQUEST_URI'], 
+		$path = urldecode($this->removeCommonPath($_SERVER['REQUEST_URI'],
 		$_SERVER['SCRIPT_NAME']));
 		$path = preg_replace('/(\/*\?.*$)|(\/$)/', '', $path);
 		$path = str_replace($this->format_map['extensions'], '', $path);
@@ -561,7 +568,7 @@ class Restler {
 			// RFC 2616: If no Accept header field is
 			// present, then it is assumed that the
 			// client accepts all media types.
-			$_SERVER['HTTP_ACCEPT'] = '*/*'; 
+			$_SERVER['HTTP_ACCEPT'] = '*/*';
 		}
 		if (strpos($_SERVER['HTTP_ACCEPT'], '*') !== FALSE) {
 			if (strpos($_SERVER['HTTP_ACCEPT'], 'application/*') !== FALSE) {
@@ -619,7 +626,7 @@ class Restler {
 			//echo PHP_EOL.$url.' = '.$this->url.PHP_EOL;
 			$call = (object)$call;
 			if(strstr($url, ':')){
-				$regex = preg_replace('/\\\:([^\/]+)/', '(?P<$1>[^/]+)', 
+				$regex = preg_replace('/\\\:([^\/]+)/', '(?P<$1>[^/]+)',
 				preg_quote($url));
 				if (preg_match(":^$regex$:", $this->url, $matches)) {
 					foreach ($matches as $arg => $match) {
@@ -657,12 +664,12 @@ class Restler {
 	 * @param Object $method_info method information and metadata
 	 */
 	protected function applyClassMetadata($class_name, $instance, $method_info){
-		if(isset($method_info->metadata[$class_name]) && 
+		if(isset($method_info->metadata[$class_name]) &&
 		is_array($method_info->metadata[$class_name])){
-			foreach ($method_info->metadata[$class_name] 
+			foreach ($method_info->metadata[$class_name]
 			as $property => $value){
 				if(property_exists($class_name, $property)){
-					$reflection_property = 
+					$reflection_property =
 					new ReflectionProperty($class_name, $property);
 					$reflection_property->setValue($instance, $value);
 				}
@@ -730,7 +737,7 @@ class Restler {
 			);
 			$method_url = strtolower($method->getName());
 			if (preg_match_all(
-			'/@url\s+(GET|POST|PUT|DELETE|HEAD|OPTIONS)[ \t]*\/?(\S*)/s', 
+			'/@url\s+(GET|POST|PUT|DELETE|HEAD|OPTIONS)[ \t]*\/?(\S*)/s',
 			$doc, $matches, PREG_SET_ORDER)) {
 				foreach ($matches as $match) {
 					$http_method = $match[1];
@@ -739,14 +746,14 @@ class Restler {
 				}
 			}elseif($method_url[0] != '_'){ //not prefixed with underscore
 				// no configuration found so use convention
-				if (preg_match_all('/^(GET|POST|PUT|DELETE|HEAD|OPTIONS)/i', 
+				if (preg_match_all('/^(GET|POST|PUT|DELETE|HEAD|OPTIONS)/i',
 				$method_url, $matches)) {
 					$http_method = strtoupper($matches[0][0]);
 					$method_url = substr($method_url, strlen($http_method));
 				}else{
 					$http_method = 'GET';
 				}
-				$url = $base_path. ($method_url=='index' || 
+				$url = $base_path. ($method_url=='index' ||
 				$method_url=='default' ? '' : $method_url);
 				$url = rtrim($url,'/');
 				$this->routes[$http_method][$url] = $call;
@@ -829,7 +836,7 @@ class DefaultResponse implements iRespond {
 		return $result;
 	}
 	function __formatError($statusCode, $message) {
-		return array('error' => array('code' => $statusCode, 
+		return array('error' => array('code' => $statusCode,
 		'message' => $message));
 	}
 }
@@ -989,8 +996,8 @@ class JsonFormat implements iFormat
 		//do nothing
 	}
 	public function encode($data, $human_readable=FALSE){
-		return $human_readable ? 
-		$this->json_format(json_encode(object_to_array($data))) : 
+		return $human_readable ?
+		$this->json_format(json_encode(object_to_array($data))) :
 		json_encode(object_to_array($data));
 	}
 	public function decode($data) {
@@ -1047,7 +1054,7 @@ class JsonFormat implements iFormat
 				case '{':
 				case '[':
 					if(!$in_string) {
-						$new_json .= $char . "\n" . 
+						$new_json .= $char . "\n" .
 						str_repeat($tab, $indent_level+1);
 						$indent_level++;
 					} else {
@@ -1132,7 +1139,7 @@ class DocParser {
 			if($parsedLine === false && !isset($this->params['description'])) {
 				if(isset($desc)){
 					//Store the first line in the short description
-					$this->params['description'] = implode(PHP_EOL, $desc); 
+					$this->params['description'] = implode(PHP_EOL, $desc);
 				}
 				$desc = array();
 			} elseif($parsedLine !== false) {
@@ -1152,22 +1159,22 @@ class DocParser {
 		if(strpos($line, '@') === 0) {
 			if(strpos($line, ' ')>0){
 				//Get the parameter name
-				$param = substr($line, 1, strpos($line, ' ') - 1); 
+				$param = substr($line, 1, strpos($line, ' ') - 1);
 				$value = substr($line, strlen($param) + 2); //Get the value
 			}else{
 				$param = substr($line, 1);
 				$value = '';
 			}
 			//Parse the line and return false if the parameter is valid
-			if($this->setParam($param, $value)) return false; 
+			if($this->setParam($param, $value)) return false;
 		}
 
 		return $line;
 	}
 	private function setParam($param, $value) {
-		if($param == 'param' || $param == 'return') 
+		if($param == 'param' || $param == 'return')
 		$value = $this->formatParamOrReturn($value);
-		if($param == 'class') 
+		if($param == 'class')
 		list($param, $value) = $this->formatClass($value);
 
 		if(empty($this->params[$param])) {
@@ -1222,7 +1229,7 @@ function parse_doc($php_doc_comment){
 	$php_doc_comment =  trim(preg_replace('/\r?\n *\* */', ' ',
 	 $php_doc_comment));
 	return $php_doc_comment;
-	preg_match_all('/@([a-z]+)\s+(.*?)\s*(?=$|@[a-z]+\s)/s', 
+	preg_match_all('/@([a-z]+)\s+(.*?)\s*(?=$|@[a-z]+\s)/s',
 	$php_doc_comment, $matches);
 	return array_combine($matches[1], $matches[2]);
 }


### PR DESCRIPTION
I've pulled out the initialization steps from the handle event and moved them into an init() method.  This change allows us to catch url formatting errors in prerouting and return an error to the client using restler.  
