### PR TITLE
A fix to a change and init() refactor

### DIFF
--- a/restler/restler.php
+++ b/restler/restler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * REST API Server. It is the server part of the Restler framework.
  * Based on the RestServer code from <http://jacwright.com/blog/resources/RestServer.txt>
@@ -184,6 +185,7 @@ class Restler
     //
     // ------------------------------------------------------------------
 
+
     /**
      * Constructor
      * @param boolean $production_mode When set to FALSE, it will run in
@@ -192,9 +194,10 @@ class Restler
     public function __construct($production_mode = FALSE)
     {
         $this->production_mode = $production_mode;
-        $this->cache_dir       = getcwd();
-        $this->base_dir        = RESTLER_PATH;
+        $this->cache_dir = getcwd();
+        $this->base_dir = RESTLER_PATH;
     }
+
 
     /**
      * Store the url map cache if needed
@@ -206,6 +209,7 @@ class Restler
         }
     }
 
+
     /**
      * Use it in production mode to refresh the url map cache
      */
@@ -214,6 +218,7 @@ class Restler
         $this->routes = array();
         $this->cached = FALSE;
     }
+
 
     /**
      * Call this method and pass all the formats that should be
@@ -245,13 +250,14 @@ class Restler
                 foreach ($mime as $value) {
                     if (!isset($this->format_map[$value]))
                         $this->format_map[$value] = $class_name;
-                    }
+                }
                 $extensions[".$extension"] = TRUE;
             }
         }
-        $this->format_map['default']    = $args[0];
+        $this->format_map['default'] = $args[0];
         $this->format_map['extensions'] = array_keys($extensions);
     }
+
 
     /**
      * Add api classes throgh this method. All the public methods
@@ -279,7 +285,7 @@ class Restler
                     $base_path = substr($base_path, $index + 1);
                 }
             } else {
-                $base_path = trim($base_path,'/');
+                $base_path = trim($base_path, '/');
             }
             if (strlen($base_path) > 0) {
                 $base_path .= '/';
@@ -287,6 +293,7 @@ class Restler
             $this->generateMap($class_name, $base_path);
         }
     }
+
 
     /**
      * protected methods will need atleast one authentication class to be set
@@ -300,6 +307,7 @@ class Restler
         $this->addAPIClass($class_name, $base_path);
     }
 
+
     /**
      * Add class for custom error handling
      * @param string $class_name of the error handling class
@@ -309,6 +317,7 @@ class Restler
         $this->error_classes[] = $class_name;
     }
 
+
     /**
      * Convenience method to respond with an error message
      * @param int $statusCode http error code
@@ -316,14 +325,14 @@ class Restler
      */
     public function handleError($status_code, $error_message = NULL)
     {
-        $method  = "handle$status_code";
+        $method = "handle$status_code";
         $handled = FALSE;
         foreach ($this->error_classes as $class_name) {
             if (method_exists($class_name, $method)) {
-                $obj          = new $class_name();
+                $obj = new $class_name();
                 $obj->restler = $this;
                 $obj->$method();
-                $handled      = TRUE;
+                $handled = TRUE;
             }
         }
         if ($handled) {
@@ -332,38 +341,43 @@ class Restler
         $message = $this->codes[$status_code]
             . (!$error_message ? '' : ': ' . $error_message);
         $this->setStatus($status_code);
-        $responder          = new $this->response();
+        $responder = new $this->response();
         $responder->restler = $this;
         $this->sendData($responder->__formatError($status_code, $message));
     }
+
 
     /**
      * An initialize function to allow use of the restler error generation functions
      * for pre-processing and pre-routing of requests.
      */
-    public function init () {
-        if(empty($this->format_map))$this->setSupportedFormats('JsonFormat');
-                $this->url = $this->getPath();
-                $this->request_method = $this->getRequestMethod();
-                $this->response_format = $this->getResponseFormat();
-                $this->request_format = $this->getRequestFormat();
-                if(is_null($this->request_format)){
-                        $this->request_format = $this->response_format;
-                }
-                if($this->request_method == 'PUT' || $this->request_method == 'POST'){
-                        $this->request_data = $this->getRequestData();
-                }
+    public function init()
+    {
+        if (empty($this->format_map))
+            $this->setSupportedFormats('JsonFormat');
+        $this->url = $this->getPath();
+        $this->request_method = $this->getRequestMethod();
+        $this->response_format = $this->getResponseFormat();
+        $this->request_format = $this->getRequestFormat();
+        if (is_null($this->request_format)) {
+            $this->request_format = $this->response_format;
+        }
+        if ($this->request_method == 'PUT' || $this->request_method == 'POST') {
+            $this->request_data = $this->getRequestData();
+        }
     }
 
-        /**
-         * Main function for processing the api request
-         * and return the response
-         * @throws Exception when the api service class is missing
-         * @throws RestException to send error response
-         */
-        public function handle () {
-                $this->init();
-                $o = $this->mapUrlToMethod();
+
+    /**
+     * Main function for processing the api request
+     * and return the response
+     * @throws Exception when the api service class is missing
+     * @throws RestException to send error response
+     */
+    public function handle()
+    {
+        $this->init();
+        $o = $this->mapUrlToMethod();
 
         if (!isset($o->class_name)) {
             $this->handleError(404);
@@ -375,7 +389,7 @@ class Restler
                         throw new RestException(401);
                     }
                     foreach ($this->auth_classes as $auth_class) {
-                        $auth_obj          = new $auth_class();
+                        $auth_obj = new $auth_class();
                         $auth_obj->restler = $this;
                         $this->applyClassMetadata($auth_class, $auth_obj, $o);
                         if (!method_exists($auth_obj, $auth_method)) {
@@ -387,7 +401,7 @@ class Restler
                     }
                 }
                 $this->applyClassMetadata(get_class($this->request_format),
-                $this->request_format, $o);
+                    $this->request_format, $o);
                 $pre_process = '_' . $this->request_format->getExtension() . '_'
                     . $o->method_name;
                 $this->service_method = $o->method_name;
@@ -397,24 +411,22 @@ class Restler
                 $object = $this->service_class_instance = new $o->class_name();
                 $object->restler = $this;
                 if (method_exists($o->class_name, $pre_process)) {
-                    call_user_func_array(array($object, $pre_process),
-                                               $o->arguments);
+                    call_user_func_array(array($object, $pre_process), $o->arguments);
                 }
                 switch ($o->method_flag) {
                     case 3:
                         $reflection_method = new ReflectionMethod($object,
-                                                                  $o->method_name);
+                                $o->method_name);
                         $reflection_method->setAccessible(TRUE);
                         $result = $reflection_method->invokeArgs($object,
-                                                                 $o->arguments);
+                            $o->arguments);
                         break;
                     case 2:
                     case 1:
                     default:
                         $result = call_user_func_array(array(
                             $object,
-                            $o->method_name),
-                            $o->arguments
+                            $o->method_name), $o->arguments
                         );
                         break;
                 }
@@ -431,6 +443,7 @@ class Restler
         }
     }
 
+
     /**
      * Encodes the response in the prefered format
      * and sends back
@@ -438,14 +451,14 @@ class Restler
      */
     public function sendData($data)
     {
-        $data =  $this->response_format->encode($data, !($this->production_mode));
-        $post_process =  '_' . $this->service_method . '_'
+        $data = $this->response_format->encode($data, !($this->production_mode));
+        $post_process = '_' . $this->service_method . '_'
             . $this->response_format->getExtension();
         if (isset($this->service_class_instance)
-            && method_exists($this->service_class_instance,$post_process)
+            && method_exists($this->service_class_instance, $post_process)
         ) {
             $data = call_user_func(array($this->service_class_instance,
-            $post_process), $data);
+                $post_process), $data);
         }
         header("Cache-Control: no-cache, must-revalidate");
         header("Expires: 0");
@@ -455,6 +468,7 @@ class Restler
         die($data);
     }
 
+
     /**
      * Sets the HTTP response status
      * @param int $code response code
@@ -463,6 +477,7 @@ class Restler
     {
         header("{$_SERVER['SERVER_PROTOCOL']} $code " . $this->codes[strval($code)]);
     }
+
 
     /**
      * Compare two strings and remove the common
@@ -475,7 +490,7 @@ class Restler
      */
     public function removeCommonPath($first, $second, $char = '/')
     {
-        $first  = explode($char, $first);
+        $first = explode($char, $first);
         $second = explode($char, $second);
         while (count($second)) {
             if ($first[0] == $second[0]) {
@@ -488,13 +503,14 @@ class Restler
         return implode($char, $first);
     }
 
+
     /**
      * Save cache to file
      */
     public function saveCache()
     {
         $file = $this->cache_dir . '/routes.php';
-        $s    = '$o=array();' . PHP_EOL;
+        $s = '$o=array();' . PHP_EOL;
         foreach ($this->routes as $key => $value) {
             $s .= PHP_EOL . PHP_EOL . PHP_EOL . "############### $key ###############"
                 . PHP_EOL . PHP_EOL;
@@ -502,20 +518,18 @@ class Restler
             foreach ($value as $ke => $va) {
                 $s .= PHP_EOL . PHP_EOL . "#==== $key $ke" . PHP_EOL . PHP_EOL;
                 $s .= '$o[\'' . $key . '\'][\'' . $ke . '\']=' . str_replace(
-                    PHP_EOL,
-                    PHP_EOL . "\t",
-                    var_export($va, TRUE)
-                ) . ';';
+                        PHP_EOL, PHP_EOL . "\t", var_export($va, TRUE)
+                    ) . ';';
             }
         }
         $s .= PHP_EOL . 'return $o;';
-        $r  = @file_put_contents($file, "<?php $s");
+        $r = @file_put_contents($file, "<?php $s");
         @chmod($file, 0777);
         if ($r === FALSE) {
             throw new Exception(
                 "The cache directory located at '$this->cache_dir' needs to have "
-                    . "the permissions set to read/write/execute for everyone in order "
-                    . "to save cache and improve performance.");
+                . "the permissions set to read/write/execute for everyone in order "
+                . "to save cache and improve performance.");
         }
     }
 
@@ -525,18 +539,20 @@ class Restler
     //
     // ------------------------------------------------------------------
 
+
     /**
-    * Parses the requst url and get the api path
-    * @return string api path
-    */
+     * Parses the requst url and get the api path
+     * @return string api path
+     */
     protected function getPath()
     {
         $path = urldecode($this->removeCommonPath($_SERVER['REQUEST_URI'],
-                                                  $_SERVER['SCRIPT_NAME']));
+                $_SERVER['SCRIPT_NAME']));
         $path = preg_replace('/(\/*\?.*$)|(\/$)/', '', $path);
         $path = str_replace($this->format_map['extensions'], '', $path);
         return $path;
     }
+
 
     /**
      * Parses the request to figure out the http request type
@@ -556,6 +572,7 @@ class Restler
         }
         return $method;
     }
+
 
     /**
      * Parses the request to figure out format of the request data
@@ -582,6 +599,7 @@ class Restler
         return $format;
     }
 
+
     /**
      * Parses the request to figure out the best format for response
      * @return iFormat any class that implements iFormat
@@ -591,12 +609,12 @@ class Restler
     {
         //check if client has specified an extension
         /**
-        * @var iFormat
-        */
+         * @var iFormat
+         */
         $format = NULL;
-        $extensions = explode('.', parse_url($_SERVER['REQUEST_URI'],
-                                             PHP_URL_PATH));
-        while($extensions) {
+        $extensions = explode('.',
+            parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
+        while ($extensions) {
             $extension = array_pop($extensions);
             $extension = explode('/', $extension);
             $extension = array_shift($extension);
@@ -611,28 +629,26 @@ class Restler
         //check if client has sent list of accepted data formats
         if (isset($_SERVER['HTTP_ACCEPT'])) {
             $acceptList = array();
-            $accepts    = explode(',', strtolower($_SERVER['HTTP_ACCEPT']));
+            $accepts = explode(',', strtolower($_SERVER['HTTP_ACCEPT']));
             if (!is_array($accepts)) {
                 $accepts = array($accepts);
             }
             foreach ($accepts as $pos => $accept) {
-                $parts   = explode(';q=', trim($accept));
-                $type    = array_shift($parts);
-                $quality = count($parts)
-                    ? floatval(array_shift($parts))
-                    : (1000 - $pos) / 1000;
+                $parts = explode(';q=', trim($accept));
+                $type = array_shift($parts);
+                $quality = count($parts) ? floatval(array_shift($parts)) : (1000 - $pos) / 1000;
                 $acceptList[$type] = $quality;
             }
             arsort($acceptList);
             foreach ($acceptList as $accept => $quality) {
                 if (isset($this->format_map[$accept])) {
-                        $format = $this->format_map[$accept];
-                        $format = is_string($format) ? new $format : $format;
-                        $format->setMIME($accept);
-                        //echo "MIME $accept";
-                        header("Vary: Accept"); // Tell cache content is based on Accept header
-                        return $format;
-                    }
+                    $format = $this->format_map[$accept];
+                    $format = is_string($format) ? new $format : $format;
+                    $format->setMIME($accept);
+                    //echo "MIME $accept";
+                    header("Vary: Accept"); // Tell cache content is based on Accept header
+                    return $format;
+                }
             }
         } else {
             // RFC 2616: If no Accept header field is
@@ -643,11 +659,9 @@ class Restler
         if (strpos($_SERVER['HTTP_ACCEPT'], '*') !== FALSE) {
             if (strpos($_SERVER['HTTP_ACCEPT'], 'application/*') !== FALSE) {
                 $format = new JsonFormat;
-            }
-            else if (strpos($_SERVER['HTTP_ACCEPT'], 'text/*') !== FALSE) {
+            } else if (strpos($_SERVER['HTTP_ACCEPT'], 'text/*') !== FALSE) {
                 $format = new XmlFormat;
-            }
-            else if (strpos($_SERVER['HTTP_ACCEPT'], '*/*') !== FALSE) {
+            } else if (strpos($_SERVER['HTTP_ACCEPT'], '*/*') !== FALSE) {
                 $format = new $this->format_map['default'];
             }
         }
@@ -664,13 +678,14 @@ class Restler
         }
     }
 
+
     /**
      * Parses the request data and returns it
      * @return array php data
      */
     protected function getRequestData()
     {
-        try{
+        try {
             $r = file_get_contents('php://input');
             if (is_null($r)) {
                 return $_GET;
@@ -682,6 +697,7 @@ class Restler
         }
     }
 
+
     protected function mapUrlToMethod()
     {
         if (!isset($this->routes[$this->request_method])) {
@@ -692,17 +708,17 @@ class Restler
             return array();
         }
 
-        $found               = FALSE;
+        $found = FALSE;
         $this->request_data += $_GET;
-        $params              = array('request_data' => $this->request_data);
-        $params             += $this->request_data;
-        $lc                  = strtolower($this->url);
+        $params = array('request_data' => $this->request_data);
+        $params += $this->request_data;
+        $lc = strtolower($this->url);
         foreach ($urls as $url => $call) {
             //echo PHP_EOL.$url.' = '.$this->url.PHP_EOL;
             $call = (object) $call;
             if (strstr($url, ':')) {
                 $regex = preg_replace('/\\\:([^\/]+)/', '(?P<$1>[^/]+)',
-                                      preg_quote($url));
+                    preg_quote($url));
                 if (preg_match(":^$regex$:i", $this->url, $matches)) {
                     foreach ($matches as $arg => $match) {
                         if (isset($call->arguments[$arg])) {
@@ -713,11 +729,11 @@ class Restler
                     $found = TRUE;
                     break;
                 }
-            // The commented line replaced the following line, but it breaks for
-            // for cases where the api is not at the root uri.
-            // we aren't necessarily looking for an exact match!
-            //} else if ($url == $lc) {
-            }elseif (strpos($lc,$url) !== false){
+                // The commented line replaced the following line, but it breaks for
+                // for cases where the api is not at the root uri.
+                // we aren't necessarily looking for an exact match!
+                //} else if ($url == $lc) {
+            } elseif (strpos($lc, $url) !== false) {
                 $found = TRUE;
                 break;
             }
@@ -735,8 +751,8 @@ class Restler
             $call->arguments = $p;
             return $call;
         }
-
     }
+
 
     /**
      * Apply static and non-static properties defined in
@@ -750,7 +766,7 @@ class Restler
         if (isset($method_info->metadata[$class_name])
             && is_array($method_info->metadata[$class_name])
         ) {
-            foreach ($method_info->metadata[$class_name] as $property => $value ) {
+            foreach ($method_info->metadata[$class_name] as $property => $value) {
                 if (property_exists($class_name, $property)) {
                     $reflection_property = new ReflectionProperty($class_name, $property);
                     $reflection_property->setValue($instance, $value);
@@ -758,6 +774,7 @@ class Restler
             }
         }
     }
+
 
     protected function loadCache()
     {
@@ -780,70 +797,65 @@ class Restler
         }
     }
 
+
     /**
      * Generates cachable url to method mapping
      * @param string $class_name
      * @param string $base_path
      */
-    protected function generateMap ($class_name, $base_path = '')
+    protected function generateMap($class_name, $base_path = '')
     {
-        $reflection     = new ReflectionClass($class_name);
+        $reflection = new ReflectionClass($class_name);
         $class_metadata = parse_doc($reflection->getDocComment());
-        $methods        = $reflection->getMethods(
+        $methods = $reflection->getMethods(
             ReflectionMethod::IS_PUBLIC + ReflectionMethod::IS_PROTECTED
         );
         foreach ($methods as $method) {
-            $doc       = $method->getDocComment();
+            $doc = $method->getDocComment();
             $arguments = array();
-            $defaults  = array();
-            $metadata  = $class_metadata + parse_doc($doc);
-            $params    = $method->getParameters();
-            $position  = 0;
+            $defaults = array();
+            $metadata = $class_metadata + parse_doc($doc);
+            $params = $method->getParameters();
+            $position = 0;
             foreach ($params as $param) {
                 $arguments[$param->getName()] = $position;
-                $defaults[$position] = $param->isDefaultValueAvailable()
-                    ? $param->getDefaultValue() : NULL;
+                $defaults[$position] = $param->isDefaultValueAvailable() ? $param->getDefaultValue() : NULL;
                 $position++;
             }
-            $method_flag = $method->isProtected()
-                ? (isRestlerCompatibilityModeEnabled() ? 2 :  3)
-                : (isset($metadata['protected']) ? 1 : 0);
+            $method_flag = $method->isProtected() ? (isRestlerCompatibilityModeEnabled() ? 2 : 3) : (isset($metadata['protected']) ? 1 : 0);
 
             //take note of the order
             $call = array(
-                'class_name'  => $class_name,
+                'class_name' => $class_name,
                 'method_name' => $method->getName(),
-                'arguments'   => $arguments,
-                'defaults'    => $defaults,
-                'metadata'    => $metadata,
+                'arguments' => $arguments,
+                'defaults' => $defaults,
+                'metadata' => $metadata,
                 'method_flag' => $method_flag
             );
             $method_url = strtolower($method->getName());
             if (preg_match_all(
-                '/@url\s+(GET|POST|PUT|DELETE|HEAD|OPTIONS)[ \t]*\/?(\S*)/s',
-                $doc,
-                $matches,
-                PREG_SET_ORDER)
+                    '/@url\s+(GET|POST|PUT|DELETE|HEAD|OPTIONS)[ \t]*\/?(\S*)/s',
+                    $doc, $matches, PREG_SET_ORDER)
             ) {
                 foreach ($matches as $match) {
                     $http_method = $match[1];
-                    $url = rtrim($base_path . $match[2],'/');
+                    $url = rtrim($base_path . $match[2], '/');
                     $this->routes[$http_method][$url] = $call;
                 }
             } else if ($method_url[0] != '_') { //not prefixed with underscore
                 // no configuration found so use convention
                 if (preg_match_all('/^(GET|POST|PUT|DELETE|HEAD|OPTIONS)/i',
-                                   $method_url,
-                                   $matches)
+                        $method_url, $matches)
                 ) {
                     $http_method = strtoupper($matches[0][0]);
-                    $method_url  = substr($method_url, strlen($http_method));
+                    $method_url = substr($method_url, strlen($http_method));
                 } else {
                     $http_method = 'GET';
                 }
                 $url = $base_path
                     . ($method_url == 'index' || $method_url == 'default' ? '' : $method_url);
-                $url = rtrim($url,'/');
+                $url = rtrim($url, '/');
                 $this->routes[$http_method][$url] = $call;
                 foreach ($params as $param) {
                     if ($param->getName() == 'request_data') {
@@ -856,6 +868,7 @@ class Restler
             }
         }
     }
+
 }
 
 if (version_compare(PHP_VERSION, '5.3.0') < 0) {
@@ -882,6 +895,7 @@ if (version_compare(PHP_VERSION, '5.3.0') < 0) {
 class RestException extends Exception
 {
 
+
     public function __construct($http_status_code, $error_message = NULL)
     {
         parent::__construct($error_message, $http_status_code);
@@ -901,12 +915,15 @@ class RestException extends Exception
  */
 interface iRespond
 {
+
+
     /**
      * Result of an api call is passed to this method
      * to create a standard structure for the data
      * @param unknown_type $result can be a primitive or array or object
      */
     public function __formatResponse($result);
+
 
     /**
      * When the api call results in RestException this method
@@ -929,10 +946,14 @@ interface iRespond
  */
 class DefaultResponse implements iRespond
 {
+
+
     function __formatResponse($result)
     {
         return $result;
     }
+
+
     function __formatError($statusCode, $message)
     {
         return array(
@@ -942,6 +963,7 @@ class DefaultResponse implements iRespond
             )
         );
     }
+
 }
 
 /**
@@ -956,6 +978,8 @@ class DefaultResponse implements iRespond
  */
 interface iAuthenticate
 {
+
+
     /**
      * Auth function that is called when a protected method is requested
      * @return boolean TRUE or FALSE
@@ -976,6 +1000,8 @@ interface iAuthenticate
  */
 interface iFormat
 {
+
+
     /**
      * Get Extension => MIME type mappings as an associative array
      * @return array list of mime strings for the format
@@ -983,15 +1009,19 @@ interface iFormat
      */
     public function getMIMEMap();
 
+
     /**
      * Set the selected MIME type
      * @param string $mime MIME type
      */
     public function setMIME($mime);
+
+
     /**
      * Get selected MIME type
      */
     public function getMIME();
+
 
     /**
      * Set the selected file extension
@@ -999,11 +1029,13 @@ interface iFormat
      */
     public function setExtension($extension);
 
+
     /**
      * Get the selected file extension
      * @return string file extension
      */
     public function getExtension();
+
 
     /**
      * Encode the given data in the format
@@ -1015,6 +1047,7 @@ interface iFormat
      * @return string encoded string
      */
     public function encode($data, $human_readable = FALSE);
+
 
     /**
      * Decode the given data from the format
@@ -1037,49 +1070,59 @@ interface iFormat
  */
 class UrlEncodedFormat implements iFormat
 {
-    const MIME      = 'application/x-www-form-urlencoded';
+
+    const MIME = 'application/x-www-form-urlencoded';
     const EXTENSION = 'post';
+
 
     public function getMIMEMap()
     {
         return array(self::EXTENSION => self::MIME);
     }
 
+
     public function getMIME()
     {
-        return  self::MIME;
+        return self::MIME;
     }
+
 
     public function getExtension()
     {
         return self::EXTENSION;
     }
 
+
     public function setMIME($mime)
     {
         //do nothing
     }
+
 
     public function setExtension($extension)
     {
         //do nothing
     }
 
+
     public function encode($data, $human_readable = FALSE)
     {
         return http_build_query($data);
     }
 
+
     public function decode($data)
     {
-        parse_str($data,$r);
+        parse_str($data, $r);
         return $r;
     }
+
 
     public function __toString()
     {
         return $this->getExtension();
     }
+
 }
 
 /**
@@ -1094,50 +1137,58 @@ class UrlEncodedFormat implements iFormat
  */
 class JsonFormat implements iFormat
 {
-    const MIME      = 'application/json,application/javascript';
-    static $mime    = 'application/json';
+
+    const MIME = 'application/json,application/javascript';
+
+    static $mime = 'application/json';
+
     const EXTENSION = 'json';
+
 
     public function getMIMEMap()
     {
         return array(self::EXTENSION => self::MIME);
     }
 
+
     public function getMIME()
     {
-        return  self::$mime;
+        return self::$mime;
     }
+
 
     public function getExtension()
     {
         return self::EXTENSION;
     }
 
+
     public function setMIME($mime)
     {
         self::$mime = $mime;
     }
+
 
     public function setExtension($extension)
     {
         //do nothing
     }
 
+
     public function encode($data, $human_readable = FALSE)
     {
-        return $human_readable
-            ? $this->json_format(json_encode(object_to_array($data)))
-            : json_encode(object_to_array($data));
+        return $human_readable ? $this->json_format(json_encode(object_to_array($data))) : json_encode(object_to_array($data));
     }
+
 
     public function decode($data)
     {
-        $decoded = json_decode ($data);
-        if (function_exists ('json_last_error')) {
+        $decoded = json_decode($data);
+        if (function_exists('json_last_error')) {
             $message = '';
-            switch (json_last_error ()) {
+            switch (json_last_error()) {
                 case JSON_ERROR_NONE:
-                    return object_to_array ($decoded);
+                    return object_to_array($decoded);
                     break;
                 case JSON_ERROR_DEPTH:
                     $message = 'maximum stack depth exceeded';
@@ -1158,12 +1209,13 @@ class JsonFormat implements iFormat
                     $message = 'unknown error';
                     break;
             }
-            throw new RestException (400, 'Error parsing JSON, ' . $message);
-        } else if (strlen ($data) && $decoded === NULL || $decoded === $data) {
-            throw new RestException (400, 'Error parsing JSON');
+            throw new RestException(400, 'Error parsing JSON, ' . $message);
+        } else if (strlen($data) && $decoded === NULL || $decoded === $data) {
+            throw new RestException(400, 'Error parsing JSON');
         }
-        return object_to_array ($decoded);
+        return object_to_array($decoded);
     }
+
 
     /**
      * Pretty print JSON string
@@ -1172,20 +1224,20 @@ class JsonFormat implements iFormat
      */
     private function json_format($json)
     {
-        $tab          = "  ";
-        $new_json     = "";
+        $tab = "  ";
+        $new_json = "";
         $indent_level = 0;
-        $in_string    = FALSE;
-        $len          = strlen($json);
+        $in_string = FALSE;
+        $len = strlen($json);
 
-        for($c = 0; $c < $len; $c++) {
+        for ($c = 0; $c < $len; $c++) {
             $char = $json[$c];
-            switch($char) {
+            switch ($char) {
                 case '{':
                 case '[':
                     if (!$in_string) {
                         $new_json .= $char . "\n" .
-                        str_repeat($tab, $indent_level + 1);
+                            str_repeat($tab, $indent_level + 1);
                         $indent_level++;
                     } else {
                         $new_json .= $char;
@@ -1215,9 +1267,9 @@ class JsonFormat implements iFormat
                     }
                     break;
                 case '"':
-                    if ($c==0) {
+                    if ($c == 0) {
                         $in_string = TRUE;
-                    } else if ($c > 0 && $json[$c-1] != '\\') {
+                    } else if ($c > 0 && $json[$c - 1] != '\\') {
                         $in_string = !$in_string;
                     }
                 default:
@@ -1229,10 +1281,12 @@ class JsonFormat implements iFormat
         return $new_json;
     }
 
+
     public function __toString()
     {
         return $this->getExtension();
     }
+
 }
 
 /**
@@ -1248,28 +1302,32 @@ class JsonFormat implements iFormat
  */
 class DocParser
 {
+
     private $params = array();
 
-    function parse($doc = '') {
+
+    function parse($doc = '')
+    {
         if ($doc == '') {
             return $this->params;
         }
         //Get the comment
         if (preg_match('#^/\*\*(.*)\*/#s', $doc, $comment) === false) {
-            return  $this->params;
+            return $this->params;
         }
         $comment = trim($comment[1]);
         //Get all the lines and strip the * from the first character
         if (preg_match_all('#^\s*\*(.*)#m', $comment, $lines) === false) {
-            return  $this->params;
+            return $this->params;
         }
         $this->parseLines($lines[1]);
-        return  $this->params;
+        return $this->params;
     }
+
 
     private function parseLines($lines)
     {
-        foreach($lines as $line) {
+        foreach ($lines as $line) {
             $parsedLine = $this->parseLine($line); //Parse the line
 
             if ($parsedLine === false && !isset($this->params['description'])) {
@@ -1287,6 +1345,7 @@ class DocParser
             $this->params['long_description'] = $desc;
         }
     }
+
 
     private function parseLine($line)
     {
@@ -1307,10 +1366,12 @@ class DocParser
                 $value = '';
             }
             //Parse the line and return false if the parameter is valid
-            if ($this->setParam($param, $value)) return false;
+            if ($this->setParam($param, $value))
+                return false;
         }
         return $line;
     }
+
 
     private function setParam($param, $value)
     {
@@ -1332,12 +1393,13 @@ class DocParser
         return true;
     }
 
+
     private function formatClass($value)
     {
         $r = preg_split("[\(|\)]", $value);
         if (count($r) > 1) {
             $param = $r[0];
-            parse_str($r[1],$value);
+            parse_str($r[1], $value);
             foreach ($value as $key => $val) {
                 $val = explode(',', $val);
                 if (count($val) > 1) {
@@ -1350,12 +1412,14 @@ class DocParser
         return array($param, $value);
     }
 
+
     private function formatParamOrReturn($string)
     {
-        $pos  = strpos($string, ' ');
+        $pos = strpos($string, ' ');
         $type = substr($string, 0, $pos);
         return '(' . $type . ')' . substr($string, $pos + 1);
     }
+
 }
 
 
@@ -1378,19 +1442,20 @@ function parse_doc($php_doc_comment)
         |(^[\\s]\\*\\/)
         |(^[\\s]*\\*?\\s)
         |(^[\\s]*)
-        |(^[\\t]*)/ixm", "", $php_doc_comment);
+        |(^[\\t]*)/ixm",
+        "", $php_doc_comment);
     $php_doc_comment = str_replace("\r", "", $php_doc_comment);
     $php_doc_comment = preg_replace("/([\\t])+/", "\t", $php_doc_comment);
     return explode("\n", $php_doc_comment);
 
-    $php_doc_comment =  trim(preg_replace('/\r?\n *\* */', ' ',
-                                          $php_doc_comment));
+    $php_doc_comment = trim(preg_replace('/\r?\n *\* */', ' ', $php_doc_comment));
     return $php_doc_comment;
 
-    preg_match_all('/@([a-z]+)\s+(.*?)\s*(?=$|@[a-z]+\s)/s',
-                   $php_doc_comment, $matches);
+    preg_match_all('/@([a-z]+)\s+(.*?)\s*(?=$|@[a-z]+\s)/s', $php_doc_comment,
+        $matches);
     return array_combine($matches[1], $matches[2]);
 }
+
 
 /**
  * Conveniance function that converts the given object
@@ -1412,7 +1477,7 @@ function object_to_array($object, $utf_encode = FALSE)
         && !($object instanceof JsonSerializable))
     ) {
         $array = array();
-        foreach($object as $key => $value) {
+        foreach ($object as $key => $value) {
             $value = object_to_array($value, $utf_encode);
             if ($utf_encode && is_string($value)) {
                 $value = utf8_encode($value);
@@ -1424,6 +1489,7 @@ function object_to_array($object, $utf_encode = FALSE)
     return $object;
 }
 
+
 /**
  * an autoloader function for loading format classes
  * @param String $class_name class name of a class that implements iFormat
@@ -1432,13 +1498,13 @@ function autoload_formats($class_name)
 {
     $class_name = strtolower($class_name);
     $file = RESTLER_PATH . "/$class_name/$class_name.php";
-    if (file_exists ($file)) {
+    if (file_exists($file)) {
         require_once ($file);
     } else {
         $file = RESTLER_PATH . "/$class_name.php";
-        if (file_exists ($file)) {
+        if (file_exists($file)) {
             require_once ($file);
-        } elseif (file_exists ("$class_name.php")) {
+        } elseif (file_exists("$class_name.php")) {
             require_once ("$class_name.php");
         }
     }
@@ -1456,9 +1522,12 @@ spl_autoload_register('autoload_formats');
  * Manage compatibility with PHP 5 < PHP 5.3
  */
 if (!function_exists('isRestlerCompatibilityModeEnabled')) {
+
+
     function isRestlerCompatibilityModeEnabled()
     {
         return FALSE;
     }
+
 }
 define('RESTLER_PATH', dirname(__FILE__));


### PR DESCRIPTION
A change was made at some point, probably to make things more efficient, but it broke a case for APIs that are not at the root, e.g.  api.mydomain.com/v1/customer/resource/123  with a class map equivalent to Appnamespace/RestApi/v1/Customer.php   I've reverted the comparison and added a note.

I refactored the initialization portion of handle() to an init() function so that it is possible to respond to error conditions using Restler prior to the handle() event, for example, when errors occur in pre-routing.

I also used netbeans to auto-format the code to something that should be PSR compliant.
