### PR TITLE
Changed error format

### DIFF
--- a/restler/restler.php
+++ b/restler/restler.php
@@ -972,8 +972,10 @@ class DefaultResponse implements iRespond
     {
         return array(
             'error' => array(
-                'code' => $statusCode,
-                'message' => $message
+                'code'       => $statusCode,
+                'message'    => $message,
+                'request'    => $_SERVER['REQUEST_METHOD'],
+                'parameters' => $_SERVER['REQUEST_URI']
             )
         );
     }


### PR DESCRIPTION
For production, I wanted a more complete error for users to see, so I included both request method and parameters.
While it's not adding a lot, it does allow for a more in-depth error report.

Old:

``` js
{
  "error": {
    "code": 404,
    "message": "Not Found"
  }
}
```

New:

``` js
{
  "error": {
    "code": 404,
    "message": "Not Found",
    "request": "GET",
    "parameters": "\/v1\/say\/hello\/show\/error"
  }
}
```
