### PR TITLE
Check if default charset is supported by client, if so - use it.

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -464,12 +464,16 @@ class Restler extends EventEmitter
         if (isset($_SERVER['HTTP_ACCEPT_CHARSET'])) {
             $found = false;
             $charList = Util::sortByPriority($_SERVER['HTTP_ACCEPT_CHARSET']);
-            foreach ($charList as $charset => $quality) {
-                if (in_array($charset, Defaults::$supportedCharsets)) {
-                    $found = true;
-                    Defaults::$charset = $charset;
-                    break;
-                }
+            if(isset($charList[Defaults::$charset])) {
+            	$found = true;
+            } else {
+            	foreach ($charList as $charset => $quality) {
+            		if (in_array($charset, Defaults::$supportedCharsets)) {
+            			$found = true;
+            			Defaults::$charset = $charset;
+            			break;
+            		}
+            	}
             }
             if (!$found) {
                 if (strpos($_SERVER['HTTP_ACCEPT_CHARSET'], '*') !== false) {


### PR DESCRIPTION
Currently Restler picks the charset that has the highest client priority as the one to send a response as. This functionality is slightly annoying if you want to change it or think the default (utf-8) is most sensible. Pull request changes this behaviour as follows:

If the Restler default charset is explicitly supported by the client, _always_ use that, else use the old functionality. Means if you change the default charset up front or if you're happy with the package default (utf-8) it is more likely to be used where possible.
