### PR TITLE
Content negotiation fix

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -988,7 +988,7 @@ class Restler extends EventEmitter
                 }
             } elseif (strpos($_SERVER['HTTP_ACCEPT'], 'text/*') !== false) {
                 if (isset($this->formatMap["application/xml"])) {
-                    $format = new XmlFormat;
+                    $format = new Format\XmlFormat;
                 }
             } elseif (strpos($_SERVER['HTTP_ACCEPT'], '*/*') !== false) {
                 $format = $this->formatMap['default'];


### PR DESCRIPTION
Hi,

I've encountered two problems in `getResponseFormat()`'s handling of Accept headers with a wildcard.

The first issue is that requests with Accept `text/*` will cause Fatal error. `new XmlFormat` should be `new Format\XmlFormat`.

The second issue is that if my API only handles JSON (I have used `$restler->setSupportedFormats('JsonFormat');`, it will still respond with XML if a request has the Accept header `text/*`.

What do you think?
