### PR TITLE
Added a flag to allow sending the wildcard in a Access Control Allow Origin Response

### DIFF
--- a/vendor/Luracast/Restler/Defaults.php
+++ b/vendor/Luracast/Restler/Defaults.php
@@ -146,7 +146,6 @@ class Defaults
      */
     public static $crossOriginResourceSharing = false;
     public static $accessControlAllowOrigin = '*';
-    public static $allowStarAsOrigin = false;
     public static $accessControlAllowMethods =
         'GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD';
 

--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -701,13 +701,14 @@ class Restler extends EventEmitter
         @header('Expires: ' . $expires);
         @header('X-Powered-By: Luracast Restler v' . Restler::VERSION);
 
-        if (Defaults::$crossOriginResourceSharing
-            && (isset($_SERVER['HTTP_ORIGIN']) || Defaults::$allowStarAsOrigin)
-        ) {
-    		$origin = (Defaults::$accessControlAllowOrigin == '*' && !Defaults::$allowStarAsOrigin
-				? $_SERVER['HTTP_ORIGIN']
-				: Defaults::$accessControlAllowOrigin);
-			header('Access-Control-Allow-Origin: ' . $origin);
+        if (Defaults::$crossOriginResourceSharing) {
+            if(Defaults::$accessControlAllowOrigin == '*' && isset($_SERVER['HTTP_ORIGIN'])) {
+                // use provided origin to allow authenticated requests
+                $origin = $_SERVER['HTTP_ORIGIN'];
+            } else {
+                $origin = Defaults::$accessControlAllowOrigin;
+            }
+            header('Access-Control-Allow-Origin: ' . $origin);
             header('Access-Control-Allow-Credentials: true');
             header('Access-Control-Max-Age: 86400');
         }


### PR DESCRIPTION
We have clients that make unauthenticated GET requests, and do not send an HTTP_ORIGIN header, so the CORS headers will never be sent for them. I added a flag to send the CORS headers even if there is no HTTP_ORIGIN specified and the default Access-Control-Allow-Origin value is '*'
