### PR TITLE
Use only the first word of the @var annotation as type

### DIFF
--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -64,6 +64,7 @@ class Resources implements iUseAuthentication
         'object' => 'Object',
         'stdClass' => 'Object',
         'mixed' => 'string',
+		'DateTime' => 'Date'
     );
 
     /**
@@ -560,6 +561,9 @@ class Resources implements iUseAuthentication
             if ($propertyMetaData !== null) {
                 $type = isset($propertyMetaData['var']) ? $propertyMetaData['var'] : 'string';
                 $description = @$propertyMetaData['description'] ?: '';
+
+				$type = explode(" ", $type);
+				$type = array_shift($type);
 
                 if (class_exists($type)) {
                     $this->_model($type);


### PR DESCRIPTION
This is a bugfix, so that comments that are followed after the type are not interpreted as type.

Example:

``` php
/**
 * @var string Foo bar baz
 */
```

Without the patch the type would be `string Foo bar baz`, with the patch it would correctly be `string`.
