### PR TITLE
Better nickname generation

### DIFF
--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -190,28 +190,7 @@ class Resources implements iUseAuthentication
                     }
                 }
 
-				$nicknameParts = $parts;
-				array_shift($nicknameParts);
-
-				$partsWithoutVariables = array_filter($nicknameParts, function($part) {
-					return substr($part, 0, 1) !== '{';
-				});
-
-				$nickname = strtolower($httpMethod) . join('', array_map('ucfirst', $partsWithoutVariables));
-
-				if (isset($m['return']['type']) and is_string($m['return']['type'])) {
-					if (preg_match('/^(set|list|array)/i', $m['return']['type'], $matches)) {
-						$nickname .= ucfirst($matches[1]);
-					}
-				}
-
-				$variables = array_diff($nicknameParts, $partsWithoutVariables);
-
-				if ($variables) {
-					$nickname .= "By" . join("And", array_map(function($part) {
-						return ucfirst(str_replace(array('{', '}'), '', $part));
-					}, $variables));
-				}
+				$nickname = $this->generateNickname((array) $route);
 
                 $parts[self::$placeFormatExtensionBeforeDynamicParts ? $pos : 0]
                     .= $this->formatString;
@@ -407,6 +386,11 @@ class Resources implements iUseAuthentication
         if (is_numeric($o)) return is_float($o) ? 'float' : 'int';
         return 'string';
     }
+
+	protected function generateNickname(array $route)
+	{
+		return $route['methodName'];
+	}
 
     private function _resourceListing()
     {


### PR DESCRIPTION
The nicknames for methods are often used by client library generators to name the methods in generated classes (e.g. the [Swagger Codegen](http://github.com/wordnik/swagger-codegen)). Currently Restler generates nicknames which contain characters which are not legal as identifiers in most languages, like `-`.

With this patch Restler now generates more natural nicknames for the Swagger manifest.

For example, with this API method:

``` php
<?php

namespace Service;

class User
{
  /**
   * @url GET /
   * @return List[\ValueObject\User]
   */
  function index()
  {
  }

  function get($id)
  {}
}
```

The generated nickname for `index` would be `getUserList`. For `get` it would be `getUserById`.

The Scheme is as follows:
1. The HTTP method lowercased
2. All route parts which are not variables
3. "By" followed by the names of all variables.
4. optional collection type, when the method indicates that it returns with "List", "Array" or "Set"
