### PR TITLE
Parsing of @throws returning always errorcode 500

### DIFF
--- a/vendor/Luracast/Restler/CommentParser.php
+++ b/vendor/Luracast/Restler/CommentParser.php
@@ -364,9 +364,7 @@ class CommentParser
 
     private function formatThrows(array $value)
     {
-        $r = array(
-            'exception' => array_shift($value)
-        );
+        $r = array();
         $r['code'] = count($value) && is_numeric($value[0])
             ? intval(array_shift($value)) : 500;
         $reason = implode(' ', $value);


### PR DESCRIPTION
Because there is a array_shift before getting the numeric value for the error-code, the error-code is alwas 500. And i found no place, where the index "exception" is used.
