### PR TITLE
Make server without mb_convert_encoding happy.

### DIFF
--- a/vendor/Luracast/Restler/Format/JsonFormat.php
+++ b/vendor/Luracast/Restler/Format/JsonFormat.php
@@ -76,7 +76,14 @@ class JsonFormat extends Format
             $result = preg_replace_callback('/\\\u(\w\w\w\w)/',
                 function($matches)
                 {
-                    return mb_convert_encoding(pack('H*', $matches[1]), 'UTF-8', 'UTF-16BE');
+                    if (function_exists('mb_convert_encoding'))
+                	{
+                		return mb_convert_encoding(pack('H*', $matches[1]), 'UTF-8', 'UTF-16BE');	
+                	}
+                	else
+                	{
+                		return iconv('UTF-16BE','UTF-8',pack('H*', $matches[1]));
+                	}
                 }
                 , $result);
         }


### PR DESCRIPTION
Some server still don't have mb_convert_encoding() installed and especially CentOS server maybe can not install the php-mbstring package. So icnv() is an alternative for mb_convert_encoding().
