### PR TITLE
Issue #195

### DIFF
--- a/vendor/Luracast/Restler/AutoLoader.php
+++ b/vendor/Luracast/Restler/AutoLoader.php
@@ -143,9 +143,13 @@ class AutoLoader
                 if (false !== $path = stream_resolve_include_path(
                         implode($slash, $includePath)
                     ))
-                    if ('composer' == end($includePath)) {
-                        static::seen(static::loadFile(
+                    if ('composer' == end($includePath) &&
+                        false !== $classmapPath = stream_resolve_include_path(
                             "$path{$slash}autoload_classmap.php"
+                        )
+                    ) {
+                        static::seen(static::loadFile(
+                            $classmapPath
                         ));
                         $paths = array_merge(
                             $paths,


### PR DESCRIPTION
Fixes Restler Autoloader, First verifies that the autoload_classmap.php file exists within the composer folder before trying to use it
