### PR TITLE
Update XmlFormat.php

### DIFF
--- a/vendor/Luracast/Restler/Format/XmlFormat.php
+++ b/vendor/Luracast/Restler/Format/XmlFormat.php
@@ -25,6 +25,7 @@ class XmlFormat extends Format
     public static $parseAttributes = true;
     public static $parseNamespaces = true;
     public static $attributeNames = array('xmlns');
+    public static $nodeValueName = 'nodeValue';
     public static $nameSpaces = array();
     /**
      * Default name for the root node.
@@ -83,7 +84,15 @@ class XmlFormat extends Format
                 $key = static::$defaultTagName;
             if (is_array($value)) {
                 $xml->startElement($key);
-                $this->write($xml, $value);
+                if(isset($value[static::$nodeValueName])) {
+                	$text = $value[static::$nodeValueName];
+                	unset($value[static::$nodeValueName]);
+                	$this->write($xml, $value);
+                	$xml->text($text);
+                }
+                else {
+                	$this->write($xml, $value);
+                }
                 $xml->endElement();
                 continue;
             } elseif (is_bool($value)) {


### PR DESCRIPTION
Additional $nodeValueName static public property.
Used to be able to have such a result : &lt;p5 height="h" weight="w"&gt;123&lt;/p5&gt;
Currently "123" should only be content of a node included in p5.

Following code :
$result->p5 = array('nodeValue' => '123', 'height' => 'h', 'weight' => 'w');
will now result in :
&lt;p5 height="h" weight="w"&gt;123&lt;/p5&gt;

This syntax were missing for instance for mrss formatting purpose.
We would be grateful you to accept this pull request in order to be able to use the regular Restler library for our mrss rest API.
