### PR TITLE
Added support for Resources.json recognizing HTTPS when behind Amazon Elastic Load Balancer

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -389,6 +389,7 @@ class Restler extends EventDispatcher
             $_SERVER['SCRIPT_NAME']
         );
         $baseUrl = $_SERVER['SERVER_PORT'] == '443' ||
+        (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') || // Amazon ELB
         (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://';
         if ($_SERVER['SERVER_PORT'] != '80' && $_SERVER['SERVER_PORT'] != '443') {
             $baseUrl .= $_SERVER['SERVER_NAME'] . ':'


### PR DESCRIPTION
AWS ELB can present an HTTPS interface to the public but communicate to its backend servers via HTTP. When this occurs, the client's browser thinks all traffic is via HTTPS, but the backend server thinks all traffic is via HTTP. To provide a method for backend servers to recognize the front-end protocol, Amazon provides a header "HTTP_X_FORWARDED_PROTO".

This commit recognizes the Amazon header and correctly sets Restler::$baseUrl to an https:// address when traffic is received via HTTP but the client is communicating to an HTTPS load balancer.

Without this patch, Restler (specifically, Resources.json and Swagger) does not work correctly when behind an Amazon Elastic Load Balancer that is providing SSL offloading.
