### PR TITLE
Update UrlEncodedFormat.php

### DIFF
--- a/vendor/Luracast/Restler/Format/UrlEncodedFormat.php
+++ b/vendor/Luracast/Restler/Format/UrlEncodedFormat.php
@@ -48,7 +48,7 @@ class UrlEncodedFormat extends Format
                 $data[$k] = $v = $v == 'true';
             } elseif (is_array($v)) {
                 $data[$k] = $v = static::decoderTypeFix($v);
-            } elseif (empty($v) && $v !== 0) {
+            } elseif (empty($v) && $v != 0) {
                 unset($data[$k]);
             }
         }


### PR DESCRIPTION
In the case where parameters from types int, float or string (maybe other too) are passed in the url standard query string with value '0' (for instance ?v1=0), Restler returns an error (Bad Request: `v1` is required but missing).
