### PR TITLE
Fixed notices & errors thrown when global error catching is enabled

### DIFF
--- a/vendor/Luracast/Restler/Scope.php
+++ b/vendor/Luracast/Restler/Scope.php
@@ -87,7 +87,10 @@ class Scope
                 static::$instances[$name] = (object)array('instance' => $r);
                 if ($name != 'Restler') {
                     $r->restler = static::get('Restler');
-                    if ($m = @$r->restler->apiMethodInfo->metadata) {
+                    if (isset($r->restler->apiMethodInfo) &&
+                        isset($r->restler->apiMethodInfo->metadata))
+                    {
+                        $m = $r->restler->apiMethodInfo->metadata;
                         $properties = Util::nestedValue(
                             $m, 'class', $name,
                             CommentParser::$embeddedDataName
@@ -108,8 +111,10 @@ class Scope
                 (static::get('Restler')->_authenticated);
         }
         if (isset(static::$instances[$name]->initPending) &&
-            $m = @static::get('Restler')->apiMethodInfo->metadata
+            isset(static::get('Restler')->apiMethodInfo) &&
+            isset(static::get('Restler')->apiMethodInfo->metadata)
         ) {
+            $m = static::get('Restler')->apiMethodInfo->metadata;
             $properties = Util::nestedValue(
                 $m, 'class', $name,
                 CommentParser::$embeddedDataName


### PR DESCRIPTION
Immediately when I started to use Restler I got off put by notices thrown caused by error suppression. I've changed the code which caused problems for me, removed the error suppression and so far it's working. I don't want to go all philosophical, I just don't believe there is a single good case where the @ operator makes sense, check out this SO question and the second answer: http://stackoverflow.com/questions/136899/suppress-error-with-operator-in-php
