### PR TITLE
Fixed Resources.php dash issue related to versioning

### DIFF
--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -187,7 +187,7 @@ class Resources implements iUseAuthentication
         $version = 1;
         if (empty($id)) {
             //do nothing
-        } elseif (false !== ($pos = strpos($id, '-'))) {
+        } elseif (false !== ($pos = strpos($id, '-v'))) {
             $version = intval(substr($id, $pos + 2));
             $id = substr($id, 0, $pos);
         } elseif ($id{0} == 'v' && is_numeric($v = substr($id, 1))) {


### PR DESCRIPTION
Fixes #237. Dash check now includes the letter 'v' to fix all cases except when the API URL actually contains a legitimate '-v'.
