### PR TITLE
Using items->$ref instead of item->type as per swagger 1.2 spec

### DIFF
--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -789,8 +789,8 @@ class Resources implements iUseAuthentication
                     $this->_model($itemType);
                     $itemType = $this->_noNamespace($itemType);
                 }
-                $properties[$key]['item'] = array(
-                    'type' => $itemType,
+                $properties[$key]['items'] = array(
+                    '$ref' => $itemType,
                     /*'description' => '' */ //TODO: add description
                 );
             } else if (preg_match('/^array\[(.+)\]$/i', $type, $matches)) {


### PR DESCRIPTION
A small change in model to support nested array types in swagger-ui 1.2
