### PR TITLE
Support classes that have properties of a custom type

### DIFF
--- a/vendor/Luracast/Restler/Routes.php
+++ b/vendor/Luracast/Restler/Routes.php
@@ -481,10 +481,22 @@ class Routes
         $props = $class->getProperties(ReflectionProperty::IS_PUBLIC);
         foreach ($props as $prop) {
             if ($c = $prop->getDocComment()) {
-                $children[$prop->getName()] =
+                $property =
                     array('name' => $prop->getName()) +
                     Util::nestedValue(CommentParser::parse($c), 'var') +
                     array('type' => 'string');
+                 
+                $type = $property['type'];
+                if(is_string($type) && class_exists($type)){
+                    list($contentType,$grandchildren) = static::getTypeAndModel(
+                        new ReflectionClass($type)
+                    );  
+                    if(is_array($grandchildren)){
+                        $property['children']=$grandchildren;
+                    }
+                }
+                  
+                $children[$prop->getName()] = $property;
             }
         }
         return array($class->getName(), $children);


### PR DESCRIPTION
Currently if a parameter is a custom type, and one of the properties of the custom type is also a custom type, the property will be passed to the handling function with the default values of the custom type and not the values passed in the API call.

Here's an example model:

REQUEST_BODY{
    people (Array[Person]),
    num_people (int)
}
Person {
    name (string),
    email (EmailAddress)
}
EmailAddress {
    address (string),
    verified (boolean)
}

Currently when the function receives the data, all of the email address objects will contain their default values instead of what was passed in the POST body.

This change fixes the issue by processing custom-typed children when generating the model.
