### PR TITLE
Update UploadFormat.php

### DIFF
--- a/vendor/Luracast/Restler/Format/UploadFormat.php
+++ b/vendor/Luracast/Restler/Format/UploadFormat.php
@@ -62,8 +62,14 @@ class UploadFormat extends Format
                 //assume that the error is due to maximum size limit
                 throw new RestException(413, "Uploaded file ({$file['name']}) is too big.");
             }
-            if ($doMimeCheck && !in_array($file['type'],
-                    self::$allowedMimeTypes)
+            $typeElements = explode('/', $file['type']);
+            $genericType = $typeElements[0].'/*';
+            if (
+                $doMimeCheck
+                && !(
+                    in_array($file['type'], self::$allowedMimeTypes)
+                    || in_array($genericType, self::$allowedMimeTypes)
+                )
             ) {
                 throw new RestException(403, "File type ({$file['type']}) is not supported.");
             }


### PR DESCRIPTION
The modification permits to define generic mime types with the following declaration:
UploadFormat::$allowedMimeTypes = array("audio/_", "video/_", "image/*");

This is consistent with the "accept" attribute of the HTML input tag.
&lt;input type="file" accept="audio/_|video/_|image/*|MIME_type" /&gt;

Regards,

Olivier
