### PR TITLE
Provide more complete example default data in Resources.php

### DIFF
--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -682,10 +682,17 @@ class Resources implements iUseAuthentication
                 . '<hr/>'
                 . implode("<hr/>", $p);
             $r->required = $this->_bodyParam['required'];
-            $r->defaultValue = "{\n    \""
-                . implode("\": \"\",\n    \"",
-                    array_keys($this->_bodyParam['names']))
-                . "\": \"\"\n}";
+            // Create default object that includes parameters to be submitted
+            $defaultObject = new \StdClass();
+            foreach ($this->_bodyParam['names'] as $name => $values) {
+                if (class_exists($values->dataType)) {
+                    $myClassName = $values->dataType;
+                    $defaultObject->$name = new $myClassName();
+                } else {
+                   $defaultObject->$name = "";
+                }
+            }
+            $r->defaultValue = (defined('JSON_PRETTY_PRINT')) ? json_encode($defaultObject, JSON_PRETTY_PRINT) : json_encode($defaultObject);
         }
         $r->paramType = 'body';
         $r->allowMultiple = false;


### PR DESCRIPTION
When an API call includes a param of a custom class, the default value provided for Swagger includes that custom class as an empty string. This patch provides a skeleton object that matches the needed param.

In the Restler "Author" example (http://restler3.luracast.com/param.html#param-and--var), Explorer would include this default JSON object which validates as invalid at submission:

```
{
    "author" : ""
}
```

This patch changes the default JSON object to the following:

```
{
    "author": {
        "name": null,
        "email": null
    }
}
```
