### PR TITLE
Changed error message for invalid `@choice` parameter to valid choices

### DIFF
--- a/vendor/Luracast/Restler/Data/Validator.php
+++ b/vendor/Luracast/Restler/Data/Validator.php
@@ -273,6 +273,7 @@ class Validator implements iValidate
 
             if (isset ($info->choice)) {
                 if (!in_array($input, $info->choice)) {
+                    $error .= ". Expected one of (" . implode(',', $info->choice) . ").";
                     throw new RestException (400, $error);
                 }
             }


### PR DESCRIPTION
When POSTing or PUTing a parameter restricted with a list of @choice options, the error message used to simply say:

```
invalid value specified for `{paramName}`
```

The error now says:

```
invalid value specified for `{paramName}`. Expected one of (choiceA,choiceB,choiceC,...)
```
