### PR TITLE
Allow additional response type (e.g. application/xml) support in Swagger-UI

### DIFF
--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -452,6 +452,8 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
         $r->apiVersion = (string)$this->restler->_requestedApiVersion;
         $r->swaggerVersion = "1.1";
         $r->basePath = $this->restler->getBaseUrl();
+        $r->produces = $this->restler->getProducedMimeTypes();
+        $r->consumes = $this->restler->getConsumedMimeTypes();
         $r->apis = array();
         return $r;
     }

--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -137,6 +137,18 @@ class Restler extends EventDispatcher
      */
     protected $formatMap = array();
     /**
+     * List of the Mime Types that can be produced as a response by this API
+     *
+     * @var array
+     */
+    protected $producedMimeTypes = array();
+    /**
+     * List of the Mime Types that are supported for incoming requests by this API
+     *
+     * @var array
+     */
+    protected $consumedMimeTypes = array();
+    /**
      * Associated array that maps formats to their respective format class name
      *
      * @var array
@@ -313,6 +325,24 @@ class Restler extends EventDispatcher
     }
 
     /**
+     * Returns a list of the mime types (e.g.  ["application/json","application/xml"]) that the API can respond with
+     * @return array
+     */
+    public function getProducedMimeTypes()
+    {
+        return $this->producedMimeTypes;
+    }
+
+    /**
+     * Returns the list of Mime Types for the request that the API can understand
+     * @return array
+     */
+    public function getConsumedMimeTypes()
+    {
+        return $this->consumedMimeTypes;
+    }
+
+    /**
      * Call this method and pass all the formats that should be  supported by
      * the API Server. Accepts multiple parameters
      *
@@ -339,6 +369,10 @@ class Restler extends EventDispatcher
             }
 
             foreach ($obj->getMIMEMap() as $mime => $extension) {
+                if($obj->isWritable())
+                    $this->producedMimeTypes[]=$mime;
+                if($obj->isReadable())
+                    $this->consumedMimeTypes[]=$mime;
                 if (!isset($this->formatMap[$extension]))
                     $this->formatMap[$extension] = $className;
                 if (!isset($this->formatMap[$mime]))
@@ -554,12 +588,12 @@ class Restler extends EventDispatcher
         }
         if (!isset($o->className))
             throw new RestException(404);
-        
+
         if(isset($this->apiVersionMap[$o->className])){
             Scope::$classAliases[Util::getShortName($o->className)]
                 = $this->apiVersionMap[$o->className][$this->requestedApiVersion];
         }
-        
+
         foreach ($this->authClasses as $auth) {
             if (isset($this->apiVersionMap[$auth])) {
                 Scope::$classAliases[$auth] = $this->apiVersionMap[$auth][$this->requestedApiVersion];


### PR DESCRIPTION
Changes to comply with Swagger spec and add support for multiple response types (e.g. application/xml) in Swagger-UI
