### PR TITLE
PHP 5.4 built-in webserver support

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -487,8 +487,13 @@ class Restler extends EventDispatcher
     {
         $format = null ;
         // check if client has sent any information on request format
-        if (!empty($_SERVER['CONTENT_TYPE'])) {
-            $mime = $_SERVER['CONTENT_TYPE'];
+        if (!empty($_SERVER['CONTENT_TYPE']) || !empty($_SERVER['HTTP_CONTENT_TYPE'])) {
+            if (!empty($_SERVER['CONTENT_TYPE'])) {
+                $mime = $_SERVER['CONTENT_TYPE'];
+            } else {
+                $mime = $_SERVER['HTTP_CONTENT_TYPE'];
+            }
+            
             if (false !== $pos = strpos($mime, ';')) {
                 $mime = substr($mime, 0, $pos);
             }


### PR DESCRIPTION
I use PHP 5.4 command line dev server for API development.
I added the code to the necessary elements.
i added content-type handling and script name elements.

usage: php -S localhost:8000 index.php
