### PR TITLE
Default only string fields to email type

### DIFF
--- a/vendor/Luracast/Restler/Routes.php
+++ b/vendor/Luracast/Restler/Routes.php
@@ -124,13 +124,13 @@ class Routes
                 $m ['name'] = $param->getName();
                 if (empty($m['label']))
                     $m['label'] = static::label($m['name']);
-                if ($m['name'] == 'email' && empty($m[CommentParser::$embeddedDataName]['type']))
-                    $m[CommentParser::$embeddedDataName]['type'] = 'email';
-                $m ['default'] = $defaults [$position];
-                $m ['required'] = !$param->isOptional();
                 if (is_null($type) && isset($m['type'])) {
                     $type = $m['type'];
                 }
+                if ($m['name'] == 'email' && empty($m[CommentParser::$embeddedDataName]['type']) && $type=='string')
+                    $m[CommentParser::$embeddedDataName]['type'] = 'email';
+                $m ['default'] = $defaults [$position];
+                $m ['required'] = !$param->isOptional();
                 $contentType = Util::nestedValue(
                     $m,
                     CommentParser::$embeddedDataName,


### PR DESCRIPTION
To allow for custom-typed email fields, fields named email should only be checked as email addresses if the field is supposed to be a string.

This fixes issue #298.
