### PR TITLE
fix preg_replace preg_split with utf-8

### DIFF
--- a/vendor/Luracast/Restler/CommentParser.php
+++ b/vendor/Luracast/Restler/CommentParser.php
@@ -180,8 +180,8 @@ class CommentParser
         }
         $description = implode(' ', $description);
         $longDescription = implode(' ', $longDescription);
-        $description = preg_replace('/\s+/ms', ' ', $description);
-        $longDescription = preg_replace('/\s+/ms', ' ', $longDescription);
+        $description = preg_replace('/\s+/msu', ' ', $description);
+        $longDescription = preg_replace('/\s+/msu', ' ', $longDescription);
         list($description, $d1)
             = $this->parseEmbeddedData($description);
         list($longDescription, $d2)
@@ -195,7 +195,7 @@ class CommentParser
             list(, $param, $value) = preg_split('/\@|\s/', $line, 3)
             + array('', '', '');
             list($value, $embedded) = $this->parseEmbeddedData($value);
-            $value = array_filter(preg_split('/\s+/ms', $value));
+            $value = array_filter(preg_split('/\s+/msu', $value));
             $this->parseParam($param, $value, $embedded);
         }
         return $this->_data;
@@ -363,7 +363,7 @@ class CommentParser
                                     $d[$key] = $val;
                                 } else {
                                     $d[$key] =
-                                        preg_replace('/\s+/ms', ' ',
+                                        preg_replace('/\s+/msu', ' ',
                                             $d[$key]);
                                 }
                             }


### PR DESCRIPTION
fix preg_replace preg_split with utf-8
if I write some word with utf-8，it will occur messy code.
thank you.
