### PR TITLE
modify validator condition of string empty and not equal to 0

### DIFF
--- a/vendor/Luracast/Restler/Data/Validator.php
+++ b/vendor/Luracast/Restler/Data/Validator.php
@@ -336,7 +336,7 @@ class Validator implements iValidate
                         $error .= '. Expecting alpha numeric value';
                         break;
                     }
-                    if ($info->required && empty($input) && $input != "0") {
+                    if ($info->required && $input === '') {
                         $error = "$name is required.";
                         break;
                     }


### PR DESCRIPTION
# Modified Validator.php:

When $input is a empty string like $input = "", the condition of ($input != 0) will return false. So I modified the operator from != to !== . Also, when $input is equal to "0", (empty($input)) will return true, modified this to $input == "" . 
Hope is will help this project to improve.

2014/06/18: add more clear syntax for the condition
 if ($info->required && empty($input) && (string)$input !== "0")
# Modified route.php:

I was trying to do this simple code.

``` php
public function postPerson(
    $FIRST_NAME,
    $LAST_NAME = "",
    $AGE
) {
    return "good";
}
```

I tried to give the $LAST_NAME parameter a default value, and expected it will skip the validator of required for $LAST_NAME, but seems it doesn't work. I found out the parameters will be parsed and have a property which is called required with a boolean value by a function isOptional(), and I refer on stack overflow

http://stackoverflow.com/questions/23774355/php-reflectionparameter-isoptional-vs-isdefaultvalueavailable

Seems it will return a boolean value true if parameters are not all optional. So, I modified to another function is called isDefaultValueAvailable()
