### PR TITLE
Add NewRelic support so transactions are grouped correctly.

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -964,6 +964,8 @@ class Restler extends EventDispatcher
         $o = & $this->apiMethodInfo;
         $accessLevel = max(Defaults::$apiAccessLevel,
             $o->accessLevel);
+        if (function_exists('newrelic_name_transaction'))
+            newrelic_name_transaction("{$o->className}/{$o->methodName}");
         $object =  Scope::get($o->className);
         switch ($accessLevel) {
             case 3 : //protected method


### PR DESCRIPTION
This may be merged, or just be a useful reference for other users who use NewRelic.

NewRelic monitors the performance of an application. It reveals slow points and what aspects are used the most. This is very useful for an API that gets a reasonable amount of traffic.

Out of the box, NewRelic can't identify the API calls and they all get pooled as /index.php.
This patch simply takes the class and method of the API and passes it on to NewRelic giving a far better result.

It will have no impact if NewRelic isn't used.
