### PR TITLE
Fixed support for Amazon ELB with HTTPS offloading

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -496,6 +496,7 @@ class Restler extends EventDispatcher
 
         if (!$this->baseUrl) {
             $port = isset($_SERVER['SERVER_PORT']) ? $_SERVER['SERVER_PORT'] : '80';
+            $port = isset($_SERVER['HTTP_X_FORWARDED_PORT']) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : $port; // Amazon ELB
             $https = $port == '443' ||
                 (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') || // Amazon ELB
                 (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on');


### PR DESCRIPTION
If Amazon ELB offloads HTTPS, a new header is added for HTTP_X_FORWARDED_PORT. This header contains the port number used to connect to the ELB by the client.
