### PR TITLE
Fix group operations with url-based versioning

### DIFF
--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -370,7 +370,7 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
 
                 if (static::$groupOperations) {
                     foreach ($r->apis as $a) {
-                        if ($a->path == "/$fullPath") {
+                        if ($a->path == "$prefix/$fullPath") {
                             $api = $a;
                             break;
                         }


### PR DESCRIPTION
When (\Luracast\Restler\Defaults::$useUrlBasedVersioning = true) and (\Luracast\Restler\Resources::$groupOperations = true), operations were not correctly grouped due to not taking into account the version in the URL. Fixed the comparitor so that it compares the version-based URL and correctly groups operations.