### PR TITLE
Fixes for authentication mechanism.

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -1171,7 +1171,10 @@ class Restler extends EventDispatcher
                     /** @var iAuthenticate $authClassInstance */
                     $authClassInstance = Scope::get($authClass);
 
-                    @header('WWW-Authenticate: '. $authClassInstance->__getWWWAuthenticateString(), false);
+                    $wwwAuthenticateString = $authClassInstance->__getWWWAuthenticateString();
+                    if (!is_null($wwwAuthenticateString)) {
+                        @header('WWW-Authenticate: ' . $wwwAuthenticateString, false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Respond with multiple WWW-Authenticate headers if multiple authentication classes have been added.

Authentication will now succeed after a single authentication class returns true,
instead of requiring all of them to return true.

Signed-off-by: Stephan Peijnik <speijnik@anexia-it.com>