### PR TITLE
[BUGFIX] show correct API's in Explorer (when we use API-class with reso...

### DIFF
--- a/vendor/Luracast/Restler/Explorer.php
+++ b/vendor/Luracast/Restler/Explorer.php
@@ -132,7 +132,16 @@ class Explorer implements iProvideMultiVersionApi
     public function get()
     {
         if (func_num_args() > 1 && func_get_arg(0) == 'resources') {
-            return $this->getResources(func_get_arg(1));
+            /**
+             * BUGFIX:
+             * If we use common resourcePath (e.g. $r->addAPIClass([api-class], 'api/shop')), than we must determine resource-ID of e.g. 'api/shop'!
+             */
+            $arguments = func_get_args();
+            // remove first entry
+            array_shift($arguments);
+            // create ID
+            $id = implode('/', $arguments);
+            return $this->getResources($id);
         }
         $filename = implode('/', func_get_args());
         $redirect = false;


### PR DESCRIPTION
Hi,
first of all: This framework is amazing! We were searching for one REST-framework for PHP (which we want to integrate in the Content-Management-System called 'TYPO3'...which is one of the biggest open-source enterprise CMS-frameworks in europe and the world) and restler is excellent for that job :-)

Now, i found out, that there's a bug in restler 3.0.0-RC6, when i define an API-class, which has an resourcePath with slash:

```php
$r->addAPIClass('dummyApiClass', 'api/shop');
```

In this case, the REST-Call works fine, BUT inside the Explorer, i can't see my API-class. Please check, if my Bugfix (which works for me) is OK und take it to your official Branch of 3.0.0-RC6.

Thank you very much!
Jürgen