### PR TITLE
[BUGFIX] fix dependency-injection when third-party DI-manager

### DIFF
--- a/vendor/Luracast/Restler/Explorer.php
+++ b/vendor/Luracast/Restler/Explorer.php
@@ -409,7 +409,24 @@ class Explorer implements iProvideMultiVersionApi
 
     private function model($type, array $children)
     {
-        $type = Util::getShortName($type);
+        /**
+         * Bugfix:
+         * If we use namespaces, than the model will not be correct, if we use a short name for the type!
+         *
+         * Example (phpDoc/annotations in API-class, which uses custom domain-model with namespace):
+         * @param Car $car {@from body} {@type Aoe\RestServices\Domain\Model\Car}
+         * @return Car {@type Aoe\RestServices\Domain\Model\Car}
+         * Than, the model (in swagger-spec) must also be 'Aoe\RestServices\Domain\Model\Car' and not 'Car'
+         *
+         * When we use namespaces, than we must use the @type-annotation, otherwise the automatic reconstitution
+         * from request-data (e.g. when it is a POST-request) to custom domain-model-object will not work!
+         *
+         * Summary:
+         * - When we use no namespaces, than the type would not be changed, if we would call 'Util::getShortName'
+         * - When we use namespaces, than the model will not be correct, if we would call 'Util::getShortName'
+         * ...so this method-call is either needless or will create a bug/error
+         */
+        //$type = Util::getShortName($type);
         if (isset($this->models[$type]))
             return $this->models[$type];
         $r = new stdClass();

--- a/vendor/Luracast/Restler/Scope.php
+++ b/vendor/Luracast/Restler/Scope.php
@@ -98,7 +98,7 @@ class Scope
             if (static::$registry[$name]->singleton) {
                 static::$instances[$name] = (object)array('instance' => $r);
             }
-        } elseif (is_callable(static::$resolver) && $name != 'Restler') {
+        } elseif (is_callable(static::$resolver) && false === stristr($name, 'Luracast\Restler')) {
             $fullName = $name;
             if (isset(static::$classAliases[$name])) {
                 $fullName = static::$classAliases[$name];
@@ -107,6 +107,7 @@ class Scope
             $function = static::$resolver;
             $r = $function($fullName);
             static::$instances[$name] = (object)array('instance' => $r);
+            static::$instances[$name]->initPending = true;
         } else {
             $fullName = $name;
             if (isset(static::$classAliases[$name])) {

--- a/vendor/Luracast/Restler/Scope.php
+++ b/vendor/Luracast/Restler/Scope.php
@@ -98,7 +98,7 @@ class Scope
             if (static::$registry[$name]->singleton) {
                 static::$instances[$name] = (object)array('instance' => $r);
             }
-        } elseif (is_callable(static::$resolver)) {
+        } elseif (is_callable(static::$resolver) && $name != 'Restler') {
             $fullName = $name;
             if (isset(static::$classAliases[$name])) {
                 $fullName = static::$classAliases[$name];


### PR DESCRIPTION
Hi,
i use my own third-party dependency-injection-manager. In Issue 423, i discribed, that the Explorer does not work, when i configure my own dependency-injection-manager. This pull request now contains the final solution/bugfix.

And the second bugfix is:
When i use my own dependency-injection-manager, configure my own Authentication-Class and use this PHPdoc-comment/anotation in my API-class, than the property 'role' was not set in my Authentication-Class:
@class CustomerAuthenticationController {@role user}

The property CustomerAuthenticationController::$role was not set, because in Scope::get, the Authentication-Class did not get the configuration 'initPending'. This Bugfix fix also that bug.

Cheers,
Jürgen Kußmann