### PR TITLE
Correction for PHP < 5.5

### DIFF
--- a/vendor/Luracast/Restler/MemcacheCache.php
+++ b/vendor/Luracast/Restler/MemcacheCache.php
@@ -133,7 +133,8 @@ class MemcacheCache implements iCache
     public function isCached($name)
     {
         function_exists('memcache_get') || $this->memcacheNotAvailable();
-        return !empty($this->memcache->get(self::$namespace . "-" . $name));
+        $data = $this->memcache->get(self::$namespace . "-" . $name);
+        return !empty($data);
     }
 
 }


### PR DESCRIPTION
isCached() was making an assumption that PHP v5.5+ is being used. Calling this function on older versions produced:
PHP Fatal error:  Can't use method return value in write context in ./vendor/luracast/restler/vendor/Luracast/Restler/MemcacheCache.php on line 136.