### PR TITLE
Temp fix for PHP 7.0.0-dev compatibility

### DIFF
--- a/features/bootstrap/RestContext.php
+++ b/features/bootstrap/RestContext.php
@@ -1,7 +1,7 @@
 <?php
 use Behat\Behat\Context\BehatContext;
 use Behat\Gherkin\Node\PyStringNode;
-use Luracast\Restler\Data\String;
+use Luracast\Restler\Data\String as Str;
 
 /**
  * Rest context.
@@ -127,7 +127,7 @@ class RestContext extends BehatContext
     public function theResponseContains($response)
     {
         $data = json_encode($this->_data);
-        if (!String::contains($data, $response))
+        if (!Str::contains($data, $response))
             throw new Exception("Response value does not contain '$response' only\n\n"
                 . $this->echoLastResponse());
     }

--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -1,7 +1,7 @@
 <?php
 namespace Luracast\Restler;
 
-use Luracast\Restler\Data\String;
+use Luracast\Restler\Data\String as Str;
 use Luracast\Restler\Scope;
 use stdClass;
 
@@ -226,14 +226,14 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
                     continue;
                 }
                 $fullPath = $route['url'];
-                if ($fullPath !== $target && !String::beginsWith($fullPath, $target)) {
+                if ($fullPath !== $target && !Str::beginsWith($fullPath, $target)) {
                     continue;
                 }
                 $fLen = strlen($fullPath);
                 if ($tSlash) {
-                    if ($fLen != $tLen && !String::beginsWith($fullPath, $target . '/'))
+                    if ($fLen != $tLen && !Str::beginsWith($fullPath, $target . '/'))
                         continue;
-                } elseif ($fLen > $tLen + 1 && $fullPath{$tLen + 1} != '{' && !String::beginsWith($fullPath, '{')) {
+                } elseif ($fLen > $tLen + 1 && $fullPath{$tLen + 1} != '{' && !Str::beginsWith($fullPath, '{')) {
                     //when mapped to root exclude paths that have static parts
                     //they are listed else where under that static part name
                     continue;
@@ -246,7 +246,7 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
                     if (empty($exclude)) {
                         if ($fullPath == $exclude)
                             continue 2;
-                    } elseif (String::beginsWith($fullPath, $exclude)) {
+                    } elseif (Str::beginsWith($fullPath, $exclude)) {
                         continue 2;
                     }
                 }
@@ -891,7 +891,7 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
         }
         $this->_mapResources($allRoutes, $map, $version);
         foreach ($map as $path => $description) {
-            if (!String::contains($path, '{')) {
+            if (!Str::contains($path, '{')) {
                 //add id
                 $r->apis[] = array(
                     'path' => $path . $this->formatString,
@@ -934,7 +934,7 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
         foreach ($allRoutes as $fullPath => $routes) {
             $path = explode('/', $fullPath);
             $resource = isset($path[0]) ? $path[0] : '';
-            if ($resource == 'resources' || String::endsWith($resource, 'index'))
+            if ($resource == 'resources' || Str::endsWith($resource, 'index'))
                 continue;
             foreach ($routes as $httpMethod => $route) {
                 if (in_array($httpMethod, static::$excludedHttpMethods)) {
@@ -948,7 +948,7 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
                     if (empty($exclude)) {
                         if ($fullPath == $exclude)
                             continue 2;
-                    } elseif (String::beginsWith($fullPath, $exclude)) {
+                    } elseif (Str::beginsWith($fullPath, $exclude)) {
                         continue 2;
                     }
                 }

--- a/vendor/Luracast/Restler/Routes.php
+++ b/vendor/Luracast/Restler/Routes.php
@@ -2,7 +2,7 @@
 namespace Luracast\Restler;
 
 use Luracast\Restler\Data\ApiMethodInfo;
-use Luracast\Restler\Data\String;
+use Luracast\Restler\Data\String as Str;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -587,7 +587,7 @@ class Routes
                 $children[$name] = $child;
             }
         } catch (Exception $e) {
-            if (String::endsWith($e->getFile(), 'CommentParser.php')) {
+            if (Str::endsWith($e->getFile(), 'CommentParser.php')) {
                 throw new RestException(500, "Error while parsing comments of `$className` class. " . $e->getMessage());
             }
             throw $e;

--- a/vendor/Luracast/Restler/UI/Forms.php
+++ b/vendor/Luracast/Restler/UI/Forms.php
@@ -3,7 +3,7 @@ namespace Luracast\Restler\UI;
 
 use Luracast\Restler\CommentParser;
 use Luracast\Restler\Data\ApiMethodInfo;
-use Luracast\Restler\Data\String;
+use Luracast\Restler\Data\String as Str;
 use Luracast\Restler\Data\ValidationInfo;
 use Luracast\Restler\Defaults;
 use Luracast\Restler\Format\UploadFormat;
@@ -292,7 +292,7 @@ class Forms implements iFilter
                 $options[] = $option;
             }
         } elseif ($p->type == 'boolean' || $p->type == 'bool') {
-            if (String::beginsWith($type, 'radio')) {
+            if (Str::beginsWith($type, 'radio')) {
                 $options[] = array('name' => $p->name, 'text' => ' Yes ',
                     'value' => 'true');
                 $options[] = array('name' => $p->name, 'text' => ' No ',
@@ -411,7 +411,7 @@ class Forms implements iFilter
             if (empty($exclude)) {
                 if ($url == $exclude)
                     return true;
-            } elseif (String::beginsWith($url, $exclude)) {
+            } elseif (Str::beginsWith($url, $exclude)) {
                 return true;
             }
         }


### PR DESCRIPTION
Hi,

I was trying to run Restler in PHP  7.0.0-dev and it all works fine, just the class Luracast\Restler\Data\String that needs to change it's name ( https://wiki.php.net/rfc/reserve_more_types_in_php_7 ).

Has a temporary fix, while you change the class name to something that you feel right, when importing change it to 
`use Luracast\Restler\Data\String as Str;`

And then Change `String::` to `Str::`