### PR TITLE
Param Array[some\type] should be translated as array{types}

### DIFF
--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -774,14 +774,14 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
                     $this->_model($itemType);
                     $itemType = $this->_noNamespace($itemType);
                 }
-                $properties[$key]['item'] = array(
+                $properties[$key]['items'] = array(
                     'type' => $itemType,
                     /*'description' => '' */ //TODO: add description
                 );
             } else if (preg_match('/^Array\[(.+)\]$/', $type, $matches)) {
                 $itemType = $matches[1];
                 $properties[$key]['type'] = 'Array';
-                $properties[$key]['item']['type'] = $itemType;
+                $properties[$key]['items']['type'] = $this->_noNamespace($itemType);
 
                 if (class_exists($itemType)) {
                     $this->_model($itemType);


### PR DESCRIPTION
Param Array[some\type] should be translated as array{types} according to [Swagger 1.1 spec](https://github.com/swagger-api/swagger-core/wiki/Datatypes/e22da2fb334170c7676cdde6e89b966e7604de13).
Parsing was tested with Swagger-UI.
Swagger v3.0.0 and "v3" branch.