### PR TITLE
removing explicit port on baseUrl

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -450,9 +450,6 @@ class Restler extends EventDispatcher
 
         $baseUrl = ($https ? 'https://' : 'http://') . $_SERVER['SERVER_NAME'];
 
-        if (!$https && $port != '80' || $https && $port != '443')
-            $baseUrl .= ':' . $port;
-
         $this->baseUrl = rtrim($baseUrl
             . substr($fullPath, 0, strlen($fullPath) - strlen($path)), '/');
 


### PR DESCRIPTION
Hi,

I making this pull request to fix a situation that i'm having.

Scenario:
Your API webserver is running on server1 on port 80.
You have server2 as a SSL proxy, that listen on 443 and proxy it to server1 on port 80.
When you see https://api-hostname.tdl/resources.json the basePath comes https://api-hostname.tdl:80/resources.json and that's not the way that i need it to API Explorer works!

I don't know if there is any major implication to change this. But for me makes all sense to me that you don't need to have an explicit port on baseUrl.
