### PR TITLE
[BUGFIX] fix model for swagger-spec (use namespaces)

### DIFF
--- a/vendor/Luracast/Restler/Explorer.php
+++ b/vendor/Luracast/Restler/Explorer.php
@@ -409,7 +409,24 @@ class Explorer implements iProvideMultiVersionApi
 
     private function model($type, array $children)
     {
-        $type = Util::getShortName($type);
+        /**
+         * Bugfix:
+         * If we use namespaces, than the model will not be correct, if we use a short name for the type!
+         *
+         * Example (phpDoc/annotations in API-class, which uses custom domain-model with namespace):
+         * @param Car $car {@from body} {@type Aoe\RestServices\Domain\Model\Car}
+         * @return Car {@type Aoe\RestServices\Domain\Model\Car}
+         * Than, the model (in swagger-spec) must also be 'Aoe\RestServices\Domain\Model\Car' and not 'Car'
+         *
+         * When we use namespaces, than we must use the @type-annotation, otherwise the automatic reconstitution
+         * from request-data (e.g. when it is a POST-request) to custom domain-model-object will not work!
+         *
+         * Summary:
+         * - When we use no namespaces, than the type would not be changed, if we would call 'Util::getShortName'
+         * - When we use namespaces, than the model will not be correct, if we would call 'Util::getShortName'
+         * ...so this method-call is either needless or will create a bug/error
+         */
+        //$type = Util::getShortName($type);
         if (isset($this->models[$type]))
             return $this->models[$type];
         $r = new stdClass();

--- a/vendor/Luracast/Restler/explorer/css/screen.css
+++ b/vendor/Luracast/Restler/explorer/css/screen.css
@@ -350,7 +350,7 @@
   font-size: .85em;
   line-height: 1.2em;
   overflow: auto;
-  max-height: 200px;
+  max-height: 400px;
   cursor: pointer;
 }
 .swagger-section .swagger-ui-wrap .model-signature ul.signature-nav {


### PR DESCRIPTION
Hi,

i have an API-class, which looks like this:
> namespace Aoe\EftRestApi\Controller\WebShop;
> use Aoe\EftRestApi\Domain\Model\Catalog\Product;
> 
> class ProductsController{
>     /**
>      * @url GET products/{productId}
>      *
>      * @param integer $productId {@min 1}
>      * @return Product {@type \Aoe\EftRestApi\Domain\Model\Catalog\Product}
>      */
>     public function getProductById($productId)
>     {
> 		return new Product();
>     }
> }

My custom domain-model-class 'Product' looks like this:
> namespace Aoe\EftRestApi\Domain\Model\Catalog;
> use Aoe\EftRestApi\Domain\Model\Catalog\Option\OptionGroup;
> class Product {
>    /**
>     * @var array {@type \Aoe\EftRestApi\Domain\Model\Catalog\Option\OptionGroup}
>     */
>    public $optionGroups = array();
> }

My custom domain-model-class 'OptionGroup' looks like this:
> namespace Aoe\EftRestApi\Domain\Model\Catalog\Option;
> class OptionGroup
> {
>     /**
>      * @var array {@type \Aoe\EftRestApi\Domain\Model\Catalog\Option\Option}
>      */
>     public $options = array();
> }

My custom domain-model-class 'Option' looks like this:
> namespace Aoe\EftRestApi\Domain\Model\Catalog\Option;
> class Option
> {
> }


The API works fine, but when i use/call the Explorer for the online-documenation, that the online-documentation does not show the correct model of my custom domain-model-classes.

The problem is, that i must use the phpDoc-annotation "{@type \Aoe\EftRestApi\Domain\Model\Catalog\Product}", so that restler can automatic create the documentation of my custom domain-model-class. But, the Explorer tells swagger, that the name of the custom domain-model is 'Product', which is wrong, because the correct name of my custom class is '\Aoe\EftRestApi\Domain\Model\Catalog\Product'.

This bugfix fixes that.

## Notice:
This Pull-Request is an Update of the Pull-Request #431 (the code of the bugfix didn't changed, but this pull-request is mergeable with the current v3-branch)