### PR TITLE
return response instead of directly outputting into buffer

### DIFF
--- a/vendor/Luracast/Restler/Defaults.php
+++ b/vendor/Luracast/Restler/Defaults.php
@@ -167,6 +167,12 @@ class Defaults
     public static $emptyBodyForNullResponse = true;
 
     /**
+     * @var bool when set to true, the response will not be outputted directly into the buffer.
+     * If set, Restler::handle() will return the response as a string.
+     */
+    public static $returnResponse = false;
+
+    /**
      * @var bool enables CORS support
      */
     public static $crossOriginResourceSharing = false;

--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -304,11 +304,20 @@ class Restler extends EventDispatcher
             $this->call();
             $this->compose();
             $this->postCall();
+            if (Defaults::$returnResponse) {
+                return $this->respond();
+            }
             $this->respond();
         } catch (Exception $e) {
             try{
+                if (Defaults::$returnResponse) {
+                    return $this->message($e);
+                }
                 $this->message($e);
             } catch (Exception $e2) {
+                if (Defaults::$returnResponse) {
+                    return $this->message($e2);
+                }
                 $this->message($e2);
             }
         }
@@ -1154,9 +1163,13 @@ class Restler extends EventDispatcher
                 : 'Unknown';
             @header('WWW-Authenticate: ' . $authString, false);
         }
-        echo $this->responseData;
         $this->dispatch('complete');
-        exit;
+        if (Defaults::$returnResponse) {
+            return $this->responseData;
+        } else {
+            echo $this->responseData;
+            exit;
+        }
     }
 
     protected function message(Exception $exception)
@@ -1198,6 +1211,9 @@ class Restler extends EventDispatcher
             $compose->message($exception),
             !$this->productionMode
         );
+        if (Defaults::$returnResponse) {
+            return $this->respond();
+        }
         $this->respond();
     }
 


### PR DESCRIPTION
First, thanks for this awesome framework!

In my use case I need to wrap the ouput of restler into a Response-Object which is currently impossible since restler echo´s the output and exits the script exuction.

You have discussed this within an other Issue (#463) and provided a possible solution. Since the original Issuer does not respond anymore I have implemented that functionality.

Woud be great if you merge it!