### PR TITLE
Fix for #357

### DIFF
--- a/vendor/Luracast/Restler/AutoLoader.php
+++ b/vendor/Luracast/Restler/AutoLoader.php
@@ -263,7 +263,7 @@ class AutoLoader
      * @return bool false unless className now exists
      */
     private function loadLastResort($className, $loader = null) {
-        $loaders = array_unique(static::$rogueLoaders);
+        $loaders = array_unique(static::$rogueLoaders,  SORT_REGULAR);
         if (isset($loader)) {
             if (false === array_search($loader, $loaders))
                 static::$rogueLoaders[] = $loader;


### PR DESCRIPTION
I had the same problem as @GregOriol in the referenced #357 issue. Composer autoloader is recommended, but with legacy code bases you might not have this choice.