### PR TITLE
[BUGFIX] fix sorting of REST-endpoints (by operations/path) when property Explorer::$groupOperations is set to true

### DIFF
--- a/vendor/Luracast/Restler/Explorer.php
+++ b/vendor/Luracast/Restler/Explorer.php
@@ -232,6 +232,15 @@ class Explorer implements iProvideMultiVersionApi
             }
             if (!empty($grouper)) {
                 $a[$path] = array_values($grouper);
+                // sort REST-endpoints by path
+                foreach ($a as & $b) {
+                    usort(
+                        $b,
+                        function ($x, $y) {
+                            return $x['path'] > $y['path'];
+                        }
+                    );
+                }
             } else {
                 $order = array(
                     'GET' => 1,


### PR DESCRIPTION
Hi,

when i change the property of Explorer::$groupOperations to true, than the REST-endpoints are NOT grouped by operations/path. Then, the REST-endpoints are grouped in that order in which the API-classes were added to restler.

Example:
apiClass1 contains Rest-Endpoint with URL /test/3
apiClass2 contains Rest-Endpoint with URL /test/2
apiClass3 contains Rest-Endpoint with URL /test/1

When i than use this code:
Explorer::$groupOperations = true;
$restler->addAPIClass(apiClass1 , 'api');
$restler->addAPIClass(apiClass2 , 'api');
$restler->addAPIClass(apiClass3 , 'api');

Than the result is, that the API-explorer shows this order:
api/test/test/3
api/test/test/2
api/test/test/1

But, the correct order should be:
api/test/test/1
api/test/test/2
api/test/test/3

This bugfix fixes the bug.