### PR TITLE
Pass original exception to handler

### DIFF
--- a/vendor/Luracast/Restler/EventDispatcher.php
+++ b/vendor/Luracast/Restler/EventDispatcher.php
@@ -44,7 +44,7 @@ class EventDispatcher
     public function __call($eventName, $params)
     {
         if (0 === strpos($eventName, 'on')) {
-            if (!@is_array($this->listeners[$eventName]))
+            if (!isset($this->listeners[$eventName]) || !is_array($this->listeners[$eventName]))
                 $this->listeners[$eventName] = array();
             $this->listeners[$eventName][] = $params[0];
         }

--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -1195,7 +1195,7 @@ class Restler extends EventDispatcher
         foreach ($this->errorClasses as $className) {
             if (method_exists($className, $method)) {
                 $obj = Scope::get($className);
-                if ($obj->$method())
+                if ($obj->$method($exception))
                     $handled = true;
             }
         }


### PR DESCRIPTION
1) In several cases I need a original exception details (file and line where it was generated) instead of RestException

index.php
```
$r = new Luracast\Restler\Restler();
$r->addErrorClass('Error500');
```

Error500.php
```
class Error500
{
    /** @var  Luracast\Restler\Restler */
    public $restler;
 
    function handle500($originalException)
    {
        $exception = $this->restler->exception;
       //code for $originalException
    }
}
```

2) when calling _error_get_last()_ it tell

Undefined index: onCompose
../Luracast/Restler/EventDispatcher.php
line 47

https://github.com/Luracast/Restler/blob/v3/vendor/Luracast/Restler/EventDispatcher.php#L47
this warning is suppressed by '@', but it's not a correct way. So I added the fix