### PR TITLE
Validator does incorrect convertation of strings "true" and "false" into 1 and 0

### DIFF
--- a/vendor/Luracast/Restler/Data/Validator.php
+++ b/vendor/Luracast/Restler/Data/Validator.php
@@ -524,6 +524,7 @@ class Validator implements iValidate
                 case 'string' :
                 case 'password' : //password fields with string
                 case 'search' : //search field with string
+                    if (is_bool($input)) $input = $input ? 'true' : 'false';
                     if (!is_string($input)) {
                         $error .= '. Expecting alpha numeric value';
                         break;


### PR DESCRIPTION
```php
//Test.php
class Test
{
    /**
     * @param string $s{@from query}
     */
    function getDumpString($s)
    {
        var_dump($s);
    }
}
```

```php
//index.php
//I disabled filter "trim" because it always corrupts input data for string "true" and "false"

\Luracast\Restler\Data\Validator::$preFilters = [];
$r = new Luracast\Restler\Restler();
$r->addAPIClass('Test');
$r->handle();

```

when I doing this call

_http://server.com/test/dumpstring?s=false_ or
_http://server.com/test/dumpstring?s=true_

1)

```json
 {
    "error": {
        "code": 400,
        "message": "Bad Request: Invalid value specified for `s`. Expecting alpha numeric value"
    },
    "debug": {
        "source": "Validator.php:671 at validate stage",
        "stages": {
            "success": [
                "get",
                "route",
                "negotiate"
            ],
            "failure": [
                "validate",
                "message"
            ]
        }
    }
}
```

2)
If comment this line
```
\Luracast\Restler\Data\Validator::$preFilters = [];
```
_http://server.com/test/dumpstring?s=true_ :
```
string(1) "1"
```

_http://server.com/test/dumpstring?s=false_ :

```json
{
    "error": {
        "code": 400,
        "message": "Bad Request: `s` is required."
    },
    "debug": {
        "source": "Validator.php:671 at validate stage",
        "stages": {
            "success": [
                "get",
                "route",
                "negotiate"
            ],
            "failure": [
                "validate",
                "message"
            ]
        }
    }
}
```