### PR TITLE
[BUGFIX] don't try to resolve primitive dataType as PHP-class

### DIFF
--- a/vendor/Luracast/Restler/Scope.php
+++ b/vendor/Luracast/Restler/Scope.php
@@ -194,6 +194,11 @@ class Scope
     {
         if (empty($className) || !is_string($className))
             return false;
+
+        if (self::isPrimitiveDataType($className)) {
+            return false;
+        }
+
         $divider = '\\';
         $qualified = false;
         if ($className{0} == $divider) {
@@ -211,5 +216,15 @@ class Scope
                 return $qualified;
         }
         return false;
+    }
+
+    /**
+     * @param string $stringName
+     * @return boolean
+     */
+    private static function isPrimitiveDataType($stringName)
+    {
+        $primitiveDataTypes = array('Array', 'array', 'bool', 'boolean', 'float', 'int', 'integer', 'string');
+        return in_array($stringName, $primitiveDataTypes);
     }
 }


### PR DESCRIPTION
Hi,
i have found a bug in method Luracast\Restler\Scope::resolve($className, array $scope)

The method get a string, which should represent a PHP-class. I can't say why, but in fact, the method is called with string-values like 'integer', 'string' or 'array'...so restler 'think' it must resolve a PHP-class, but it currently also try to resolve primitive dataTypes.

The bug seems to not be critical. But in my case (we use restler in combination with the TYPO3-CMS) the bug is critical, because the bug results in a lot of (needless) 'TYPO3-Caching-Requests' (because TYPO3 cache infos about PHP-classes in a file-based cache), which resulted in pure performance and crashed some REST-API-calls.