### PR TITLE
In rare cases HTTP_ORIGIN is missing from request headers

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -718,7 +718,8 @@ class Restler extends EventDispatcher
                     . $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']);
 
             header('Access-Control-Allow-Origin: ' .
-                (Defaults::$accessControlAllowOrigin == '*' ? $_SERVER['HTTP_ORIGIN'] : Defaults::$accessControlAllowOrigin));
+                ((Defaults::$accessControlAllowOrigin == '*' && isset($_SERVER['HTTP_ORIGIN']))
+                    ? $_SERVER['HTTP_ORIGIN'] : Defaults::$accessControlAllowOrigin));
             header('Access-Control-Allow-Credentials: true');
 
             exit(0);


### PR DESCRIPTION
In rare cases there is a notice in server logs:
Undefined index: HTTP_ORIGIN in .../vendor/Luracast/Restler/Restler.php on line 721
https://github.com/Luracast/Restler/blob/v3/vendor/Luracast/Restler/Restler.php#L721