### PR TITLE
Secure getsource.php do not allow to list content of files outside public/examples

### DIFF
--- a/public/examples/resources/getsource.php
+++ b/public/examples/resources/getsource.php
@@ -5,7 +5,7 @@ if (isset($_GET['file'])) {
     $file = '../' . $file;
     $filepath = realpath($file);
     $basepath = realpath('../../');
-    if (strpos($basepath, $filepath) === 0) {
+    if (strpos($filepath, $basepath) === 0 || strpos($filepath, 'public/examples') === false) {
         #trying to get the source outside restler examples
         die('not allowed');
     }


### PR DESCRIPTION
the getsource.php is not secure enough, and allows to list content of arbitrary files if restler is placed in the webroot.

see https://github.com/AOEpeople/TYPO3_Restler/issues/25
