### PR TITLE
URL decoding of parameters must be done after the parsing

### DIFF
--- a/vendor/Luracast/Restler/Restler.php
+++ b/vendor/Luracast/Restler/Restler.php
@@ -499,7 +499,7 @@ class Restler extends EventDispatcher
                 = '/' . substr($_SERVER['SCRIPT_FILENAME'], strlen($_SERVER['DOCUMENT_ROOT']) + 1);
 
         list($base, $path) = Util::splitCommonPath(
-            strtok(urldecode($_SERVER['REQUEST_URI']), '?'), //remove query string
+            strtok($_SERVER['REQUEST_URI'], '?'), //remove query string
             $_SERVER['SCRIPT_NAME']
         );
 

--- a/vendor/Luracast/Restler/Routes.php
+++ b/vendor/Luracast/Restler/Routes.php
@@ -430,7 +430,7 @@ class Routes
                     $details = $value[$httpMethod]['metadata']['param'][$index];
                     if ($k{0} == 's' || strpos($k, static::pathVarTypeOf($v)) === 0) {
                         //remove the newlines
-                        $data[$details['name']] = trim($v, PHP_EOL);
+                        $data[$details['name']] = trim(urldecode($v), PHP_EOL);
                     } else {
                         $status = 400;
                         $message = 'invalid value specified for `'


### PR DESCRIPTION
Otherwise percent-encoded / are recognized as an URL separator
which does not respect the section 2.4 of the RFC3986 [0].
This is an issue if you have an string URL parameter with a /
character since the URL is decoded before the finding the route
corresponding the request you will either not find the route
or find a route that does not match with the request. The URL
must be decoded only when setting the parameters.

[0] https://tools.ietf.org/html/rfc3986#section-2.4

 > When a URI is dereferenced, the components and subcomponents
   significant to the scheme-specific dereferencing process (if any)
   must be parsed and separated before the percent-encoded octets within
   those components can be safely decoded, as otherwise the data may be
   mistaken for component delimiters.