### PR TITLE
Use . for string concatenation instead of + to prevent PHP warnings

### DIFF
--- a/vendor/Luracast/Restler/CommentParser.php
+++ b/vendor/Luracast/Restler/CommentParser.php
@@ -280,7 +280,7 @@ class CommentParser
                 $value[self::$embeddedDataName]
                     += $data[$param][self::$embeddedDataName];
             }
-            $data[$param] = $value + $data[$param];
+            $data[$param] = $value . $data[$param];
         }
     }
 


### PR DESCRIPTION
Fixes issue #618 