### PR TITLE
Remove curly brace syntax for PHP 7.4 support.

### DIFF
--- a/vendor/Luracast/Restler/Scope.php
+++ b/vendor/Luracast/Restler/Scope.php
@@ -203,7 +203,7 @@ class Scope
 
         $divider = '\\';
         $qualified = false;
-        if ($className{0} == $divider) {
+        if ($className[0] == $divider) {
             $qualified = trim($className, $divider);
         } elseif (array_key_exists($className, $scope)) {
             $qualified = $scope[$className];


### PR DESCRIPTION
Removed curly brace syntax based on rfc - https://wiki.php.net/rfc/deprecate_curly_braces_array_access

For now we got exception when running on php7.4:
```
Array and string offset access syntax with curly braces is deprecated
```

Same as https://github.com/Luracast/Restler/pull/628 but for `v3` branch.