### PR TITLE
Swagger fixes for Restler v2\Explorer implementation

### DIFF
--- a/vendor/Luracast/Restler/Explorer/v2/Explorer.php
+++ b/vendor/Luracast/Restler/Explorer/v2/Explorer.php
@@ -296,6 +296,9 @@ class Explorer implements iProvideMultiVersionApi
             $info = new ValidationInfo($param);
             $description = isset($param['description']) ? $param['description'] : '';
             if ('body' == $info->from) {
+                if ($param['name'] === Defaults::$fullRequestDataName) {
+                    continue;
+                }
                 if ($info->required) {
                     $required = true;
                 }

--- a/vendor/Luracast/Restler/Explorer/v2/Explorer.php
+++ b/vendor/Luracast/Restler/Explorer/v2/Explorer.php
@@ -13,6 +13,7 @@ use stdClass;
 use Luracast\Restler\Data\Text;
 use Luracast\Restler\Data\ValidationInfo;
 use Luracast\Restler\Scope;
+use Luracast\Restler\Defaults;
 
 /**
  * Class Explorer
@@ -213,6 +214,7 @@ class Explorer implements iProvideMultiVersionApi
     private function paths($version = 1)
     {
         $map = Routes::findAll(static::$excludedPaths + array($this->base()), static::$excludedHttpMethods, $version);
+        $prefix = Defaults::$useUrlBasedVersioning ? "/v$version" : '';
         $paths = array();
         foreach ($map as $path => $data) {
             $access = $data[0]['access'];
@@ -226,7 +228,7 @@ class Explorer implements iProvideMultiVersionApi
                     continue;
                 }
                 $url = $route['url'];
-                $paths["/$url"][strtolower($route['httpMethod'])] = $this->operation($route);
+                $paths["$prefix/$url"][strtolower($route['httpMethod'])] = $this->operation($route);
             }
         }
 


### PR DESCRIPTION
When using Explorer v2 there are some inconsistencies to the old Resources implementation. The first issue is that the request_data optional fields appears in the generated swagger.json. The second issue is that the useUrlBasedVersioning config option is not honoured when building the swagger.json, thus the swagger.json paths do not have the API version in the path.

use Luracast\Restler\Restler;
use Luracast\Restler\Explorer\v2;
use Luracast\Restler\Defaults;

Defaults::$useUrlBasedVersioning = true;

$r = new Restler();
$r->setAPIVersion(1);
$r->addAPIClass("Explorer", "explorer2");

