### PR TITLE
[BUGFIX] Fix PHP 8.0 deprecation warnings in Routes.php

### DIFF
--- a/vendor/Luracast/Restler/Routes.php
+++ b/vendor/Luracast/Restler/Routes.php
@@ -133,8 +133,15 @@ class Routes
             }
             foreach ($params as $param) {
                 $children = array();
-                $type =
-                    $param->isArray() ? 'array' : $param->getClass();
+                $type = version_compare(phpversion(), '7.0.0', '<') ?
+                  // PHP < 7.0
+                  ($param->isArray() ? 'array' : $param->getClass()) :
+                  // PHP >= 7.0
+                  ($param->getType() && $param->getType()->getName() === 'array' ? 'array' : (
+                    $param->getType() && !$param->getType()->isBuiltin()
+                        ? new ReflectionClass($param->getType()->getName())
+                        : null
+                  ));
                 $arguments[$param->getName()] = $position;
                 $defaults[$position] = $param->isDefaultValueAvailable() ?
                     $param->getDefaultValue() : null;

--- a/vendor/Luracast/Restler/Routes.php
+++ b/vendor/Luracast/Restler/Routes.php
@@ -133,10 +133,10 @@ class Routes
             }
             foreach ($params as $param) {
                 $children = array();
-                $type = version_compare(phpversion(), '7.0.0', '<') ?
-                  // PHP < 7.0
+                $type = version_compare(phpversion(), '8.0.0', '<') ?
+                  // PHP < 8.0
                   ($param->isArray() ? 'array' : $param->getClass()) :
-                  // PHP >= 7.0
+                  // PHP >= 8.0
                   ($param->getType() && $param->getType()->getName() === 'array' ? 'array' : (
                     $param->getType() && !$param->getType()->isBuiltin()
                         ? new ReflectionClass($param->getType()->getName())


### PR DESCRIPTION
This is a backwards compatible fix that resolves PHP 8.0 deprecation warnings:

https://www.php.net/manual/en/reflectionparameter.isarray.php
https://www.php.net/manual/en/reflectionparameter.getclass.php

For PHP prior to 8.0, this will retain the original method calls. For 8.0+, it will use the new getType method on ReflectionParameter.