### PR TITLE
[BUGFIX] Fix PHP 8.0 usort deprecation warning in Resources.php

### DIFF
--- a/vendor/Luracast/Restler/Resources.php
+++ b/vendor/Luracast/Restler/Resources.php
@@ -403,9 +403,11 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
                 return
                     $a->operations[0]->httpMethod ==
                     $b->operations[0]->httpMethod
-                        ? $a->path > $b->path
-                        : $order[$a->operations[0]->httpMethod] >
-                        $order[$b->operations[0]->httpMethod];
+                        ? strcmp($a->path, $b->path)
+                        : strcmp(
+                            $order[$a->operations[0]->httpMethod],
+                            $order[$b->operations[0]->httpMethod]
+                        );
 
             }
         );
@@ -923,7 +925,7 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
         curl_setopt($ch, CURLOPT_HTTPHEADER, array(
             'Accept:application/json',
         ));
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);        
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
         $result = json_decode(curl_exec($ch));
         $http_status = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
         return array($http_status, $result);


### PR DESCRIPTION
This is a backwards compatible fix that resolves PHP 8.0 deprecation warning when returning a boolean from usort() instead of an integer:

`Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero`

(unintentional whitespace removal as well...)