### PR TITLE
Override response description on swagger content

### DIFF
--- a/public/annotations.html
+++ b/public/annotations.html
@@ -263,12 +263,12 @@ Check out supported child attributes under <a href="param.html" target="_blank">
 
 <p><strong>Syntax:</strong></p>
 
-<pre><code>@throws RestException [httpStatusCode] [Reason]
+<pre><code>@throws RestException [httpStatusCode] [Description]
 </code></pre>
 
 <p>or</p>
 
-<pre><code>@throws AnyOtherException [Reason]
+<pre><code>@throws AnyOtherException [Description]
 </code></pre>
 
 <p><strong>Example:</strong></p>

--- a/src/Explorer/v2/Explorer.php
+++ b/src/Explorer/v2/Explorer.php
@@ -403,6 +403,10 @@ class Explorer implements iProvideMultiVersionApi
         $return = Util::nestedValue($route, 'metadata', 'return');
         if (!empty($return)) {
             $this->setType($r[$code]->schema, new ValidationInfo($return));
+
+            if (!empty($return['description'])) {
+                $r[$code]->description = $return['description'];
+            }
         }
 
         if (is_array($throws = Util::nestedValue($route, 'metadata', 'throws'))) {


### PR DESCRIPTION
* Follow documentation provided at https://swagger.io/docs/specification/describing-responses/
* Override default value "Succes" when a description is provided in phpdoc ```@return```
* solve #565