### PR TITLE
Make form_key/csrf token regeneration configurable.

### DIFF
--- a/src/UI/Forms.php
+++ b/src/UI/Forms.php
@@ -48,6 +48,12 @@ class Forms implements iFilter
      * @var ValidationInfo
      */
     public static $validationInfo = null;
+    /**
+     * @var bool Should every instance of the form have unique form_key (csrf token)?
+     *
+     */
+    public static $form_key_regenerate = true;
+
     protected static $inputTypes = array(
         'hidden',
         'password',
@@ -434,6 +440,7 @@ class Forms implements iFilter
             $action = Scope::get('Restler')->url;
         }
         $target = "$method $action";
+        static::$key = static::$form_key_regenerate ? static::$key : $_SESSION[static::FORM_KEY];
         if (empty(static::$key[$target])) {
             static::$key[$target] = md5($target . User::getIpAddress() . uniqid(mt_rand()));
         }


### PR DESCRIPTION
Fix #662

This change will allow to make form_key/csrf token regeneration configurable. It will allow following two scheme for csrf token generation using boolean setting `Form::$form_key_regenerate`

1. New form_key/csrf token for every instance of a form.
2. Single form_key/csrf token for all instance of a form thought the entire session.

Default will be 1 scheme