### PR TITLE
clean the baseUrl so restler can be not in root

### DIFF
--- a/src/Restler.php
+++ b/src/Restler.php
@@ -528,6 +528,19 @@ class Restler extends EventDispatcher
             $this->baseUrl .= $base;
         }
 
+        $baseUrlInfo = parse_url($this->baseUrl);
+        if (isset($baseUrlInfo['path'])) {
+            $baseUrlCleaned = $baseUrlInfo['path'];
+        } else {
+            $baseUrlCleaned = $this->baseUrl;
+        }
+
+        if ($baseUrlCleaned !== false) {
+            if (0 === strpos($path, ltrim($baseUrlCleaned, '/'))) {
+                $path = substr($path, strlen($baseUrlCleaned));
+            }
+        }
+
         $path = str_replace(
             array_merge(
                 $this->formatMap['extensions'],


### PR DESCRIPTION
I have noticed the baseUrl doens't work as I would expect. 
If baseUrl is /endpoint/rest/ and the explorer lives in "explorer" (so with path /endpoint/rest/explorer) the route can't be found, because it will do in router.php
/endpoint/rest/explorer==explorer
so it can't be found.

If you remove the baseUrl from the path it will work
path /endpoint/rest/explorer wil be cleaned to explorer
in in router.php
explorer==explorer