### PR TITLE
Fixes truncation of input parameters

### DIFF
--- a/src/Format/UrlEncodedFormat.php
+++ b/src/Format/UrlEncodedFormat.php
@@ -25,8 +25,25 @@ class UrlEncodedFormat extends Format
 
     public function decode($data)
     {
-        parse_str($data, $r);
-        return self::decoderTypeFix($r);
+        $numberOfVariablesInQuery = substr_count($data, '&') + 1;
+
+        // if there are more input variables on the string than specified by max_input_vars directive, then further
+        // input variables are truncated from the request
+        if ($numberOfVariablesInQuery < (int) ini_get('max_input_vars')) {
+            parse_str($data, $result);
+
+            return self::decoderTypeFix($result);
+        }
+
+        $parsedVariables = [];
+
+        foreach (explode('&', $data) as $variableString) {
+            $parsedVariable = null;
+            parse_str($variableString, $parsedVariable);
+            $parsedVariables[] = $parsedVariable;
+        }
+
+        return self::decoderTypeFix(array_merge_recursive(...$parsedVariables));
     }
 
     public static function encoderTypeFix(array $data)


### PR DESCRIPTION
If there are more input variables on the string than specified by `max_input_vars` directive, then further input variables are truncated from the request.

If a request signature based on a parameter list is used for authorization, then after the parameter list is truncated, the signature will not match and the user will receive an authorization error. An unobvious problem is that the user can use a maximum of 998 parameters, since the last parameters will be occupied by the signature of the request and the username that is used on the server to verify the signature.

Of course, for queries with a large number of parameters, it is better to use JSON, but the authorization error and the limit of 998 parametersin this case are not at all obvious.