### PR TITLE
Use native php function to handle autoloader callables

### DIFF
--- a/src/AutoLoader.php
+++ b/src/AutoLoader.php
@@ -287,18 +287,11 @@ class AutoLoader
      */
     private function loadThisLoader($className, $loader)
     {
-        if (is_array($loader)
-            && is_callable($loader)) {
-            $b = new $loader[0];
-            if (false !== $file = $b::$loader[1]($className)
-                    && $this->exists($className, $b::$loader[1])) {
-                return $file;
-            }
-        } elseif (is_callable($loader)
-            && false !== $file = $loader($className)
-                && $this->exists($className, $loader)) {
-            return $file;
-        }
+		if (is_callable($loader)
+			&& false !== $file = call_user_func($loader, $className)
+				&& $this->exists($className, $loader)) {
+			return $file;
+		}
         return false;
     }
 


### PR DESCRIPTION
Fix #673 

This commit https://github.com/Luracast/Restler/commit/b3ded4194057951ac96a41104f76b4b2eed62cc7 introduced a weird way to handle autoloader callables, where a simple native php function `call_user_func` can do the trick.

If approved and merged, would you consider backport it to 3 and 4 branches ?

Thx 😗 