### PR TITLE
add a security check before calling property

### DIFF
--- a/src/AutoLoader.php
+++ b/src/AutoLoader.php
@@ -290,10 +290,12 @@ class AutoLoader
         if (is_array($loader)
             && is_callable($loader)) {
             $b = new $loader[0];
-            if (false !== $file = $b::$loader[1]($className)
-                    && $this->exists($className, $b::$loader[1])) {
-                return $file;
-            }
+			if(property_exists($b, $loader[1])) {
+                if (false !== $file = $b::$loader[1]($className)
+                        && $this->exists($className, $b::$loader[1])) {
+                    return $file;
+                }
+			}
         } elseif (is_callable($loader)
             && false !== $file = $loader($className)
                 && $this->exists($className, $loader)) {


### PR DESCRIPTION
That check is to avoid PHP Fatal error: Uncaught Error: Access to undeclared static property: Composer\Autoload\ClassLoader::$loader in case of multiple autoloader systems collision
