### PR TITLE
Fix for upstream package change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev":{
         "ext-libxml": "*",
         "guzzlehttp/guzzle":"~7",
-        "bshaffer/oauth2-server-php":"dev-master",
+        "bshaffer/oauth2-server-php":"dev-main",
         "behat/behat": "^3.10@dev",
         "rize/uri-template": "dev-master",
         "illuminate/view": "^8 || ^7",


### PR DESCRIPTION
Fix upstream package change for Restler 5. Tested against php 8.5:

```
$ php -v
PHP 8.5.7 (cli) (built: Jun  2 2026 20:59:56) (NTS gcc aarch64)
Copyright (c) The PHP Group
Built by Amazon Linux
Zend Engine v4.5.7, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.7, Copyright (c), by Zend Technologies
```

All tests pass:

```
$ php -S localhost:8080 -t public server.php & sleep 1 && vendor/behat/behat/bin/behat

.
.
.
285 scenarios (285 passed)
1530 steps (1530 passed)
0m3.50s (8.12Mb)
```
