### PR TITLE
V5 php 8.5 nullable fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "bshaffer/oauth2-server-php":"If you want to use OAuth2 for authentication"
     },
     "require":{
-        "php": ">=5.4",
+        "php": ">=7.1",
         "ext-json": "*"
     },
     "require-dev":{
         "ext-libxml": "*",
         "guzzlehttp/guzzle":"~7",
-        "bshaffer/oauth2-server-php":"dev-master",
+        "bshaffer/oauth2-server-php":"dev-main",
         "behat/behat": "^3.10@dev",
         "rize/uri-template": "dev-master",
         "illuminate/view": "^8 || ^7",

--- a/src/Data/Validator.php
+++ b/src/Data/Validator.php
@@ -49,7 +49,7 @@ class Validator implements iValidate
      *
      * @throws Invalid
      */
-    public static function alpha($input, ValidationInfo $info = null)
+    public static function alpha($input, ?ValidationInfo $info = null)
     {
         if (ctype_alpha($input)) {
             return $input;
@@ -73,7 +73,7 @@ class Validator implements iValidate
      *
      * @throws Invalid
      */
-    public static function uuid($input, ValidationInfo $info = null)
+    public static function uuid($input, ?ValidationInfo $info = null)
     {
         if (is_string($input) && preg_match(
                 '/^\{?[0-9a-f]{8}\-?[0-9a-f]{4}\-?[0-9a-f]{4}\-?[0-9a-f]{4}\-?[0-9a-f]{12}\}?$/i',
@@ -96,7 +96,7 @@ class Validator implements iValidate
      *
      * @throws Invalid
      */
-    public static function alphanumeric($input, ValidationInfo $info = null)
+    public static function alphanumeric($input, ?ValidationInfo $info = null)
     {
         if (ctype_alnum($input)) {
             return $input;
@@ -120,7 +120,7 @@ class Validator implements iValidate
      *
      * @throws Invalid
      */
-    public static function printable($input, ValidationInfo $info = null)
+    public static function printable($input, ?ValidationInfo $info = null)
     {
         if (ctype_print($input)) {
             return $input;
@@ -144,7 +144,7 @@ class Validator implements iValidate
      *
      * @throws Invalid
      */
-    public static function hex($input, ValidationInfo $info = null)
+    public static function hex($input, ?ValidationInfo $info = null)
     {
         if (ctype_xdigit($input)) {
             return $input;
@@ -163,7 +163,7 @@ class Validator implements iValidate
      * @return string
      * @throws Invalid
      */
-    public static function color($input, ValidationInfo $info = null)
+    public static function color($input, ?ValidationInfo $info = null)
     {
         if (preg_match('/^#[a-f0-9]{6}$/i', $input)) {
             return $input;
@@ -183,7 +183,7 @@ class Validator implements iValidate
      *
      * @throws Invalid
      */
-    public static function tel($input, ValidationInfo $info = null)
+    public static function tel($input, ?ValidationInfo $info = null)
     {
         if (is_numeric($input) && '-' != substr($input, 0, 1)) {
             return $input;
@@ -203,7 +203,7 @@ class Validator implements iValidate
      * @return string
      * @throws Invalid
      */
-    public static function email($input, ValidationInfo $info = null)
+    public static function email($input, ?ValidationInfo $info = null)
     {
         $r = filter_var($input, FILTER_VALIDATE_EMAIL);
         if ($r) {
@@ -226,7 +226,7 @@ class Validator implements iValidate
      * @return string
      * @throws Invalid
      */
-    public static function ip($input, ValidationInfo $info = null)
+    public static function ip($input, ?ValidationInfo $info = null)
     {
         $r = filter_var($input, FILTER_VALIDATE_IP);
         if ($r) {
@@ -247,7 +247,7 @@ class Validator implements iValidate
      * @return string
      * @throws Invalid
      */
-    public static function url($input, ValidationInfo $info = null)
+    public static function url($input, ?ValidationInfo $info = null)
     {
         $r = filter_var($input, FILTER_VALIDATE_URL);
         if ($r) {
@@ -270,7 +270,7 @@ class Validator implements iValidate
      * @return string
      * @throws Invalid
      */
-    public static function date($input, ValidationInfo $info = null)
+    public static function date($input, ?ValidationInfo $info = null)
     {
         if (
             preg_match(
@@ -299,7 +299,7 @@ class Validator implements iValidate
      * @return string
      * @throws Invalid
      */
-    public static function datetime($input, ValidationInfo $info = null)
+    public static function datetime($input, ?ValidationInfo $info = null)
     {
         if (
             preg_match('/^(?P<year>19\d\d|20\d\d)\-(?P<month>0[1-9]|1[0-2])\-' .
@@ -327,7 +327,7 @@ class Validator implements iValidate
      * @return string
      * @throws Invalid
      */
-    public static function time24($input, ValidationInfo $info = null)
+    public static function time24($input, ?ValidationInfo $info = null)
     {
         return static::time($input, $info);
     }
@@ -343,7 +343,7 @@ class Validator implements iValidate
      * @return string
      * @throws Invalid
      */
-    public static function time($input, ValidationInfo $info = null)
+    public static function time($input, ?ValidationInfo $info = null)
     {
         if (preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/', $input)) {
             return $input;
@@ -365,7 +365,7 @@ class Validator implements iValidate
      * @return string
      * @throws Invalid
      */
-    public static function time12($input, ValidationInfo $info = null)
+    public static function time12($input, ?ValidationInfo $info = null)
     {
         if (preg_match(
             '/^([1-9]|1[0-2]|0[1-9]){1}(:[0-5][0-9])?\s?([aApP][mM]{1})?$/',
@@ -389,7 +389,7 @@ class Validator implements iValidate
      * @return int
      * @throws Invalid
      */
-    public static function timestamp($input, ValidationInfo $info = null)
+    public static function timestamp($input, ?ValidationInfo $info = null)
     {
         if ((string)(int)$input == $input
             && ($input <= PHP_INT_MAX)

--- a/src/RestException.php
+++ b/src/RestException.php
@@ -77,7 +77,7 @@ class RestException extends Exception
      * @param array       $details        any extra detail about the exception
      * @param Exception   $previous       previous exception if any
      */
-    public function __construct($httpStatusCode, $errorMessage = null, array $details = array(), Exception $previous = null)
+    public function __construct($httpStatusCode, $errorMessage = null, array $details = array(), ?Exception $previous = null)
     {
         $events = Scope::get('Restler')->getEvents();
         if(count($events)<= 1){

--- a/src/Restler.php
+++ b/src/Restler.php
@@ -1090,7 +1090,7 @@ class Restler extends EventDispatcher
             );
     }
 
-    public function composeHeaders(RestException $e = null)
+    public function composeHeaders(?RestException $e = null)
     {
         //only GET method should be cached if allowed by API developer
         $expires = $this->requestMethod === 'GET' ? Defaults::$headerExpires : 0;


### PR DESCRIPTION
Implicitly nullable parameters now mandatory in php8.5 which breaks Restler 5 - see https://www.php.net/manual/en/migration84.deprecated.php

Code in some places already uses nullables which came in php7.1 so version 5 of Restler cannot run on php5. I increased the min version of Restler 5 to php 7.1 in composer.json 

Tests pass:

```
$ php -S localhost:8080 -t public server.php & sleep 1 && vendor/behat/behat/bin/behat
.
.
.
285 scenarios (285 passed)
1530 steps (1530 passed)
0m4.32s (8.12Mb)

$ php -v
PHP 8.5.7 (cli) (built: Jun  2 2026 20:59:56) (NTS gcc aarch64)
Copyright (c) The PHP Group
Built by Amazon Linux
Zend Engine v4.5.7, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.7, Copyright (c), by Zend Technologies

```
