### PR TITLE
Support HTTP_X_FORWARDED_PROTO header

### DIFF
--- a/src/Resources.php
+++ b/src/Resources.php
@@ -455,6 +455,9 @@ class Resources implements iUseAuthentication, iProvideMultiVersionApi
         $r->apiVersion = (string)$this->restler->_requestedApiVersion;
         $r->swaggerVersion = "1.1";
         $r->basePath = $this->restler->getBaseUrl();
+        if (isset($_SERVER["HTTP_X_FORWARDED_PROTO"])) {
+            $r->basePath = str_replace("http:", $_SERVER["HTTP_X_FORWARDED_PROTO"].":", $r->basePath);
+        }
         $r->produces = $this->restler->getWritableMimeTypes();
         $r->consumes = $this->restler->getReadableMimeTypes();
         $r->apis = array();


### PR DESCRIPTION
For when swagger is behind an https load balancer but the target hosts are http.